### PR TITLE
Implement infinite scroll

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -146,33 +146,6 @@ body {
     text-align: center;
 }
 
-/*** Course search pagination bar ***/
-
-#course-search-pagination-bar {
-    padding-top: 15px;
-    padding-bottom: 20px;
-}
-
-#course-search-fewer-pages-button-wrapper {
-    display: inline-block;
-    padding-right: 10px;
-}
-
-#course-search-more-pages-button-wrapper {
-    display: inline-block;
-}
-
-#course-search-one-page-button-wrapper {
-    display: inline-block;
-    float: right;
-}
-
-#course-search-all-pages-button-wrapper {
-    display: inline-block;
-    float: right;
-    padding-left: 10px;
-}
-
 /** Selected courses **/
 
 #selected-courses-column {

--- a/src/index.html
+++ b/src/index.html
@@ -59,29 +59,6 @@
 
         <ul id="course-search-results-list" class="courses-list">
         </ul>
-
-        <div id="course-search-pagination-bar" class="toolbar">
-          <div id="course-search-fewer-pages-button-wrapper">
-            <button type="button" id="course-search-fewer-pages-button" class="btn btn-secondary">
-              Show fewer results
-            </button>
-          </div>
-          <div id="course-search-more-pages-button-wrapper">
-            <button type="button" id="course-search-more-pages-button" class="btn btn-secondary" role="button">
-              Show more results
-            </button>
-          </div>
-          <div id="course-search-all-pages-button-wrapper">
-            <button type="button" id="course-search-all-pages-button" class="btn btn-secondary">
-              Show all results
-            </button>
-          </div>
-          <div id="course-search-one-page-button-wrapper">
-            <button type="button" id="course-search-one-page-button" class="btn btn-secondary">
-              Show fewest results
-            </button>
-          </div>
-        </div>
       </div>
       <div id="schedule-column" class="hidden">
         <table id="schedule-table">


### PR DESCRIPTION
Implement infinite scroll
Implement "End of Result" text under results

Performance concern:
Checking whether we have to run "updateCourseSearchResults" every 300ms is very fast. The update itself, however, is slow because it always rerun search filter on gCourseList from the first item until we get to the number of items we want.

Note that this infinite scroll feature is not slower than manually clicking next page.

The updateCourseSearchResults re-paginate time can be reduced greatly by saving the last index visited in gCourseList. When we re-paginate, we can then start from the last index visited populate the list with more children.