### PR TITLE
fix course display bug

### DIFF
--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -613,8 +613,8 @@ function attachListeners()
 function updateNumCourseSearchPagesDisplayed()
 {
   let currentScrollPosition = courseSearchScheduleColumn.scrollTop;
-  let scrollingMaxPosition = courseSearchScheduleColumn.scrollHeight;
-  let scrollHeightLeft = scrollingMaxPosition - currentScrollPosition;
+  let scrollMaxPosition = courseSearchScheduleColumn.scrollHeight;
+  let scrollHeightLeft = scrollMaxPosition - currentScrollPosition;
   let screenHeight = document.documentElement.clientHeight;
 
   if (scrollHeightLeft < 2 * screenHeight)

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1003,11 +1003,8 @@ function updateCourseSearchResults(attrs)
   gNextIncrementalCourseSearchIndex = courseListIndex;
   if (allCoursesDisplayed)
   {
-    if (courseSearchResultsList.length != gCourseList.length)
-    {
-      let hasResult = numAdded != 0;
-      courseSearchResultsList.appendChild(createCourseSearchEndOfResult(hasResult));
-    }
+    let hasResult = numAdded != 0;
+    courseSearchResultsList.appendChild(createCourseSearchEndOfResult(hasResult));
     gMaxCourseSearchPage = Math.ceil(numAdded / courseSearchPageSize);
     gCourseSearchPagesShown = gMaxCourseSearchPage;
   }

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -612,12 +612,12 @@ function attachListeners()
 
 function updateNumCourseSearchPagesDisplayed()
 {
-  let currentScrollingPosition = courseSearchScheduleColumn.scrollTop;
-  let indexLastItemSecondToLastPage = (gCourseSearchPagesShown - extraPagesToLoad) *
-                                      courseSearchPageSize;
-  const pixelHeightPerItem = 41; // <- got it from inspecting element
-  let thresholdPosition = indexLastItemSecondToLastPage * pixelHeightPerItem;
-  if (currentScrollingPosition > thresholdPosition)
+  let currentScrollPosition = courseSearchScheduleColumn.scrollTop;
+  let scrollingMaxPosition = courseSearchScheduleColumn.scrollHeight;
+  let scrollHeightLeft = scrollingMaxPosition - currentScrollPosition;
+  let screenHeight = document.documentElement.clientHeight;
+
+  if (scrollHeightLeft < 2 * screenHeight)
   {
     setCourseSearchPagesDisplayed("more");
   }

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -990,7 +990,6 @@ function updateCourseSearchResults(attrs)
       {
         // If we've already added all the courses we were supposed to,
         // abort.
-        gNextIncrementalCourseSearchIndex = courseListIndex;
         allCoursesDisplayed = false;
         break;
       }
@@ -1001,11 +1000,16 @@ function updateCourseSearchResults(attrs)
         createCourseEntity(course, { alreadyAdded }));
     }
   }
+  gNextIncrementalCourseSearchIndex = courseListIndex;
   if (allCoursesDisplayed)
   {
-    let hasResult = numAdded != 0;
-    courseSearchResultsList.appendChild(createCourseSearchEndOfResult(hasResult));
+    if (courseSearchResultsList.length != gCourseList.length)
+    {
+      let hasResult = numAdded != 0;
+      courseSearchResultsList.appendChild(createCourseSearchEndOfResult(hasResult));
+    }
     gMaxCourseSearchPage = Math.ceil(numAdded / courseSearchPageSize);
+    gCourseSearchPagesShown = gMaxCourseSearchPage;
   }
 }
 


### PR DESCRIPTION
Fix course display bug where courses search display the result twice. The bug is caused by the line `gNextIncrementalCourseSearchIndex = courseListIndex;` not being executed when the result reaches the end.