### PR TITLE
Only course list/schedule scrolls in left column

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -54,7 +54,6 @@ body {
 .two-column-left {
     float: left;
     height: 100%;
-    overflow-y: auto;
     width: 70%;
 }
 
@@ -69,7 +68,6 @@ body {
 
 #course-search-schedule-column {
     padding-top: 20px;
-    overflow-y: scroll;
 }
 
 #course-search-toggle-wrapper {
@@ -101,7 +99,7 @@ body {
 /** Course search **/
 
 #course-search-column {
-    /* nothing to do here */
+    height: 100%;
 }
 
 /*** Course search header bar ***/
@@ -310,6 +308,8 @@ body {
     list-style-type: none;
     margin: 1px 0;
     padding: 0;
+    height: 100%;
+    overflow-y: auto;
 }
 
 .course-box {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -96,6 +96,11 @@ body {
     width: 100%;
 }
 
+#schedule-column {
+    height: 93%;
+    overflow-y: auto;
+}
+
 /** Course search **/
 
 #course-search-column {
@@ -308,7 +313,7 @@ body {
     list-style-type: none;
     margin: 1px 0;
     padding: 0;
-    height: 100%;
+    height: 85%;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
In the course search, only the course list (and not the toolbar and search bar) scrolls so that the user can easily make changes to the search without having to scroll up and down. In the schedule, only the schedule (and not the toolbar) scrolls.