### PR TITLE
Use correct element to detect scroll changes

### DIFF
--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -784,8 +784,8 @@ function onResize() {
 
 function updateNumCourseSearchPagesDisplayed()
 {
-  let currentScrollPosition = courseSearchScheduleColumn.scrollTop;
-  let scrollMaxPosition = courseSearchScheduleColumn.scrollHeight;
+  let currentScrollPosition = courseSearchResultsList.scrollTop;
+  let scrollMaxPosition = courseSearchResultsList.scrollHeight;
   let scrollHeightLeft = scrollMaxPosition - currentScrollPosition;
   let screenHeight = document.documentElement.clientHeight;
 


### PR DESCRIPTION
Resolves #89, resolves #104.  

(The fix is simple; opening a PR partly for documentation's sake.)

The reason behind the performance errors is that `updateNumCourseSearchPagesDisplayed` is using the wrong scroll parameters to calculate when to update the course list.  It's currently using `courseSearchScheduleColumn`, which has a fixed (i.e. not changing with more course items) scroll height and is not scrollable; instead, the scrollable container it _should_ use is `courseSearchResultsList`.  Changing these references there largely fixes the performance issues.

---

Some discovery process and evidence:

Some print-statement debugging reveals the following:
- `updateCourseSearchResults` is firing many times a second without any user input (it shouldn't!  The only thing that should passively trigger updateCourseSearchResults is API updates, and those only arrive once every 5 seconds).
  - It turns out, via a search for `setTimeout`, that `autoUpdateNumCourseSearchPagesDisplayed` runs `updateNumCourseSearchPagesDisplayed` on 100ms intervals.
  - Commenting out `autoUpdate...Displayed` disables scroll-loading, _but_ it does fix performance issues. 
- `setCourseSearchPagesDisplayed` also fires many times a second, each time with `action == "more"`.
  - `updateNumCourseSearchPages` must be (incorrectly) triggering additional `set..(more)` calls; examining its logic and inspecting some HTML reveals the error.
  - When the references to `..ScheduleColumn` are replaced with `..ResultsList`, `set..` (and correspondingly `update..`) is no longer firing many times a second.
- Successive calls to `updateCourseSearchResults` are _always_ growing the search list, even when no scrolling is occurring (not good: grows should only happen when scrolling down occurs). 
![hyperschedule-cancer](https://user-images.githubusercontent.com/3887189/63633840-1428c900-c63e-11e9-951b-398dda1e46cc.gif)
  - When the references to `..ScheduleColumn` are replaced with `..ResultsList`, the search list is no longer growing aggressively but instead grows predictably in response to scrolling.
- The API data is _not_ growing (good).
  - That means the issue is not on the API side, but on the rendering side.

---

Some explanations for issues:

- #89: performance issues are probably arising from a skyrocketing DOM and 100ms-repeated calls to `updateCourseSearchResults`.
- #104: perhaps there's some race condition occurring, with the 100ms-calls to updateCourseSearchResults getting so bogged down that successive calls begin before the previous one finishes, and so as the list grows, tens to hundreds of copies of `updateCourseSearchResults` are trying to re-add the same elements to the course search list.