### PR TITLE
Implement virtualized scrolling

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -34,11 +34,9 @@
 }
 
 .toolbar {
-    display: table;
-    margin: 0 auto;
+    display: flex;
     padding: 0;
-    table-layout: fixed;
-    width: 95%;
+    margin: 0 1em;
 }
 
 /** Page layout **/
@@ -72,16 +70,13 @@ body {
 
 #course-search-schedule-column {
     padding-top: 20px;
+    display: flex;
+    flex-direction: column;
 }
 
-#course-search-toggle-wrapper {
-    display: table-cell;
-    vertical-align: middle;
-}
-
-#schedule-toggle-wrapper {
-    display: table-cell;
-    vertical-align: middle;
+#course-search-toggle-wrapper, #schedule-toggle-wrapper {
+    flex-grow: 1;
+    flex-basis: 0;
 }
 
 #course-search-toggle {
@@ -107,11 +102,29 @@ body {
 /** Course search **/
 
 #course-search-column {
-    height: 100%;
+    flex-basis: 0;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#course-search-column.hidden {
+    display: none;
+}
+
+#course-search-results {
+    overflow-y: auto;
+    flex-basis: 0;
+    flex-grow: 1;
+    position: relative;
 }
 
 #course-search-results-list {
-    overflow-y: auto;
+    height: 0;
+}
+
+#course-search-results-placeholder {
+    position: relative;
 }
 
 /*** Course search header bar ***/
@@ -176,11 +189,12 @@ body {
     background-color: #b8b8ff;
 }
 
-/*** Course search placeholder ***/
+/*** Course search end of list ***/
 
-#course-search-placeholder {
-    margin: 15px;
+#course-search-results-end {
+    margin: .5em 1em 1em 1em;
     text-align: center;
+    color: gray;
 }
 
 /** Selected courses **/
@@ -380,18 +394,26 @@ body {
     padding: 0;
 }
 
+.course-list .course-box {
+    margin: 0px 1em;
+}
+
+#course-search-results-list .course-box {
+    position: absolute;
+}
+
 .course-box {
     cursor: pointer;
     margin: 0 auto;
     padding: 6px 0;
     position: relative;
-    width: 95%;
+    width: 100%;
     font-size: 0.8em;
 }
 
 .course-box-content {
     display: block;
-    margin: 0 auto;
+    margin: 0 1em;
     position: relative;
     padding-left: 5px;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -73,8 +73,11 @@
           </div>
         </div>
 
-        <ul id="course-search-results-list" class="courses-list">
-        </ul>
+        <div id="course-search-results">
+          <div id="course-search-results-placeholder"></div>
+          <ul id="course-search-results-list" class="courses-list"></ul>
+          <div id="course-search-results-end"></div>
+        </div>
       </div>
       <div id="schedule-column" class="hidden">
         <table id="schedule-table">

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1412,7 +1412,7 @@ function handleCourseSearchInputUpdate()
 function handleSelectedCoursesUpdate()
 {
   // We need to add/remove the "+" buttons.
-  updateCourseSearchResults();
+  rerenderCourseSearchResults();
 
   // Obviously the selected courses list needs to be rebuilt.
   updateSelectedCoursesList();

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -32,7 +32,10 @@ const courseSearchColumn = document.getElementById("course-search-column");
 const scheduleColumn = document.getElementById("schedule-column");
 
 const courseSearchInput = document.getElementById("course-search-course-name-input");
+const courseSearchResults = document.getElementById("course-search-results");
 const courseSearchResultsList = document.getElementById("course-search-results-list");
+const courseSearchResultsPlaceholder = document.getElementById("course-search-results-placeholder");
+const courseSearchResultsEnd = document.getElementById("course-search-results-end");
 
 const selectedCoursesColumn = document.getElementById("selected-courses-column");
 const importExportDataButton = document.getElementById("import-export-data-button");
@@ -70,11 +73,8 @@ let gGreyConflictCourses = greyConflictCoursesOptions[0];
 
 // Transient data.
 let gCurrentlySorting = false;
-let gCourseSearchPagesShown = courseSearchPagesShownStart;
-// gMaxCourseSearchPage starts as Infinity and stays infinity until we
-// exhaust the search result, at which point, it is calculated and set.
-let gMaxCourseSearchPage = Infinity;
-let gNextIncrementalCourseSearchIndex = null;
+let gCourseEntityHeight = 0;
+let gFilteredCourseKeys = [];
 
 /// Utility functions
 //// JavaScript utility functions
@@ -724,6 +724,11 @@ function attachListeners()
 {
   window.onload = onResize();
 
+  let ent = createCourseEntity("placeholder");
+  courseSearchResultsList.appendChild(ent);
+  gCourseEntityHeight = ent.clientHeight;
+  courseSearchResultsList.removeChild(ent);
+
   courseSearchToggle.addEventListener("click", displayCourseSearchColumn);
   scheduleToggle.addEventListener("click", displayScheduleColumn);
   closedCoursesToggle.addEventListener("click", toggleClosedCourses);
@@ -753,6 +758,9 @@ function attachListeners()
   selectedCoursesList.addEventListener("sortstop", () => {
     gCurrentlySorting = false;
   });
+
+  courseSearchResults.addEventListener("scroll", rerenderCourseSearchResults);
+  window.addEventListener("resize", rerenderCourseSearchResults);
 
   for (let i = 0; conflictCoursesRadios[i]; i++) {
     conflictCoursesRadios[i].addEventListener("click", () => {
@@ -789,55 +797,7 @@ function onResize() {
   updateCourseSearchBar();
 }
 
-function updateNumCourseSearchPagesDisplayed()
-{
-  let currentScrollPosition = courseSearchResultsList.scrollTop;
-  let scrollMaxPosition = courseSearchResultsList.scrollHeight;
-  let scrollHeightLeft = scrollMaxPosition - currentScrollPosition;
-  let screenHeight = document.documentElement.clientHeight;
-
-  if (scrollHeightLeft < 2 * screenHeight)
-  {
-    setCourseSearchPagesDisplayed("more");
-  }
-}
-
-function autoUpdateNumCourseSearchPagesDisplayed()
-{
-  updateNumCourseSearchPagesDisplayed();
-  setTimeout(autoUpdateNumCourseSearchPagesDisplayed, 100);
-}
-
 //// DOM element creation
-
-function createCourseLoadingMessage()
-{
-  const listItem = document.createElement("li");
-  listItem.id = "course-search-placeholder";
-  listItem.setAttribute("data-placeholder", "true");
-  const text = document.createTextNode("Loading courses...");
-  listItem.appendChild(text);
-  return listItem;
-}
-
-function createCourseSearchEndOfResult(hasResult = true)
-{
-  const listItem = document.createElement("li");
-  listItem.id = "course-search-placeholder";
-  listItem.setAttribute("data-placeholder", "true");
-  let text;
-  if (hasResult)
-  {
-    text = document.createTextNode("End of results");
-  }
-  else
-  {
-    text = document.createTextNode("No results");
-  }
-  listItem.setAttribute("style", "color: grey");
-  listItem.appendChild(text);
-  return listItem;
-}
 
 function createCourseEntity(course, attrs)
 {
@@ -1114,7 +1074,7 @@ function processSearchText()
   const query = getSearchQuery(queryText);
   const filters = getSearchTextFilters(filtersText);
 
-  return [query, filters];
+  return {query, filters};
   
 }
 
@@ -1182,77 +1142,79 @@ function updateConflictCoursesRadio()
   }
 }
 
-function updateCourseSearchResults(attrs)
+
+function updateCourseSearchResults()
 {
-  attrs = attrs || {};
-  const incremental = attrs.incremental;
-
-  if (!incremental)
-  {
-    gMaxCourseSearchPage = Infinity;
-    gNextIncrementalCourseSearchIndex = null;
-  }
-
   if (gApiData === null)
   {
-    let child;
-    while ((child = courseSearchResultsList.lastChild))
-    {
-      courseSearchResultsList.removeChild(child);
-    }
-    courseSearchResultsList.appendChild(createCourseLoadingMessage());
+    gFilteredCourseKeys = [];
+  }
+  else
+  {
+    const {query, filters} = processSearchText();
+
+    gFilteredCourseKeys =
+      gApiData === null
+      ? []
+      : Object.keys(gApiData.data.courses)
+      .filter(
+        key => {
+          const course = gApiData.data.courses[key];
+          return courseMatchesSearchQuery(course, query)
+            && coursePassesTextFilters(course, filters)
+            && (gShowClosedCourses || !isCourseClosed(course));
+        }
+      );
+  }
+
+  rerenderCourseSearchResults();
+}
+
+function rerenderCourseSearchResults() {
+  if (gApiData === null) {
+    courseSearchResultsEnd.textContent = "Loading API data...";
     return;
   }
 
-  let numToShow = gCourseSearchPagesShown * courseSearchPageSize;
-
   // Remove courses that should no longer be shown (or all courses, if
   // updating non-incrementally).
-  while (courseSearchResultsList.childElementCount >
-         (incremental ? numToShow : 0))
+  while (courseSearchResultsList.childElementCount > 0)
   {
     // Make sure to remove from the end.
     courseSearchResultsList.removeChild(courseSearchResultsList.lastChild);
   }
 
+  let numToShow = document.documentElement.clientHeight / gCourseEntityHeight * 3;
+  const startIndex = Math.floor(
+    (courseSearchResults.scrollTop
+     - document.documentElement.clientHeight
+    ) / gCourseEntityHeight
+  );
+
   let numAlreadyShown = courseSearchResultsList.childElementCount;
-  const queryAndFilters = processSearchText();
-  const query = queryAndFilters[0];
-  const textFilters = queryAndFilters[1];
   let allCoursesDisplayed = true;
   // 0 in case of non-incremental update
   let numAdded = numAlreadyShown;
-  let courseListIndex = gNextIncrementalCourseSearchIndex || 0;
-  let index = 0;
-  _.forEach((course) => {
-    if (index++ < courseListIndex)
-      return null;
-    const matchesQuery = courseMatchesSearchQuery(course, query);
-    const passesTextFilters = coursePassesTextFilters(course, textFilters);
-    if (matchesQuery && passesTextFilters && (gShowClosedCourses || !isCourseClosed(course)) && ( !gHideStarredConflictingCourses || !courseConflictWithSchedule(course,true) ) && ( !gHideAllConflictingCourses || !courseConflictWithSchedule(course,false)))
-    {
-      if (numAdded >= numToShow)
-      {
-        // If we've already added all the courses we were supposed to,
-        // abort.
-        allCoursesDisplayed = false;
-        return false;
-      }
-      ++numAdded;
-      const alreadyAdded = courseAlreadyAdded(course);
-      courseSearchResultsList.appendChild(
-        createCourseEntity(course, { alreadyAdded }));
-    }
-    return null;
-  }, gApiData.data.courses);
-  gNextIncrementalCourseSearchIndex = courseListIndex;
-  if (allCoursesDisplayed)
-  {
-    let hasResult = numAdded != 0;
-    courseSearchResultsList.appendChild(createCourseSearchEndOfResult(hasResult));
-    gMaxCourseSearchPage = Math.ceil(numAdded / courseSearchPageSize);
-    gCourseSearchPagesShown = gMaxCourseSearchPage;
+
+  for (
+    let index = Math.max(startIndex, 0);
+    index < Math.min(startIndex + numToShow, gFilteredCourseKeys.length);
+    ++index
+  ) {
+    const course = gApiData.data.courses[gFilteredCourseKeys[index]];
+    const alreadyAdded = courseAlreadyAdded(course);
+    const entity = createCourseEntity(course, { alreadyAdded });
+    entity.style.top = "" + gCourseEntityHeight * index + "px";
+    courseSearchResultsList.appendChild(entity);
   }
+
+  courseSearchResultsPlaceholder.style.height =
+    (gCourseEntityHeight * gFilteredCourseKeys.length) + "px";
+
+  courseSearchResultsEnd.textContent =
+    gFilteredCourseKeys.length != 0
+    ? "End of results"
+    : "No results";
 }
 
 function updateSelectedCoursesList()
@@ -1379,7 +1341,6 @@ function updateSearchScheduleColumn() {
     - searchScheduleToggleBar.offsetHeight
     - courseSearchBar.offsetHeight
     - placeholderHeight;
-  courseSearchResultsList.style.height = "" + listHeight + "px";
 
   const scheduleHeight = courseSearchScheduleColumn.offsetHeight
     - columnPaddingTop
@@ -1445,7 +1406,6 @@ function setCourseDescriptionBox(course)
 
 function handleCourseSearchInputUpdate()
 {
-  gCourseSearchPagesShown = courseSearchPagesShownStart;
   updateCourseSearchResults();
 }
 
@@ -1601,37 +1561,6 @@ function displayScheduleColumn()
   gScheduleTabSelected = true;
   updateTabToggle();
   writeStateToLocalStorage();
-}
-
-function setCourseSearchPagesDisplayed(action)
-{
-  let numPages = gCourseSearchPagesShown;
-  if (action === "one")
-  {
-    numPages = 1;
-  }
-  else if (action === "fewer")
-  {
-    --numPages;
-  }
-  else if (action === "more")
-  {
-    ++numPages;
-  }
-  else if (action === "all")
-  {
-    numPages = gMaxCourseSearchPage;
-  }
-  if (numPages !== null)
-  {
-    numPages = Math.max(numPages, 1);
-    numPages = Math.min(numPages, gMaxCourseSearchPage);
-  }
-  if (numPages !== gCourseSearchPagesShown)
-  {
-    gCourseSearchPagesShown = numPages;
-    updateCourseSearchResults({ incremental: true });
-  }
 }
 
 //// Course retrieval
@@ -2165,8 +2094,7 @@ function downloadICalFile()
 attachListeners();
 readStateFromLocalStorage();
 handleGlobalStateUpdate();
-retrieveCourseDataUntilSuccessful();
-autoUpdateNumCourseSearchPagesDisplayed();
+//retrieveCourseDataUntilSuccessful();
 
 /// Closing remarks
 

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -2094,7 +2094,7 @@ function downloadICalFile()
 attachListeners();
 readStateFromLocalStorage();
 handleGlobalStateUpdate();
-//retrieveCourseDataUntilSuccessful();
+retrieveCourseDataUntilSuccessful();
 
 /// Closing remarks
 


### PR DESCRIPTION
Re-resolves #104.

Currently, the course search results list is a "classic" infinite/incremental scroller, wherein about two screen-heights' worth of DOM is rendered at first (as opposed to all 2000+, one for each course), and more is rendered as the user scrolls down the results list.  There's a few downsides to this approach:
1. The scrollbar acts janky as new items are rendered--every time you scroll down, new items are added, and the scroll area becomes taller, so the scroll bar "teleports" up.  Long-time users of infinite-scrollers are accustomed to this jankiness, but it's not a good thing to be accustomed to.  Related:
  - The scrollbar provides no estimate as to how large the total list should be, or how far into the list the user currently has scrolled (not that this is critical information to have, but it's a nice UI touch that is missing with this approach).
  - There's no nice way to "skip" to the bottom of the scroll list: you have to scroll down, let new items render and the scrollbar teleport, then scroll again, and again, until eventually you reach bottom.  Scrolling experience: 2/5.

  ![hyperschedule-janky-scroll](https://user-images.githubusercontent.com/3887189/63645705-c79fc500-c6f3-11e9-910c-fc0936c1be01.gif)
2. Performance gets worse the farther you scroll down, since new elements are rendered in but no elements are removed, so the DOM becomes more and more bloated (despite the same, fixed amount of content being actually visible on screen).  By the time you scroll to the bottom of the 2000+ course list, latency is back up to 1+ seconds.

  ![hyperschedule-scroll-deterioration](https://user-images.githubusercontent.com/3887189/63645756-a68ba400-c6f4-11e9-8ae9-843d5af06e59.gif)

3. (Not an issue with infinite scrolling, but a bug the current behavior: previously, the course list was completely broken, loading in multiple duplicate copies of the same courses; see #104.  I _thought_ I had fixed that in #105, but it turns out I must not have looked at the incremental rendering logic carefully enough, because the performance issues were fixed, but the duplicate courses are very much still there!)
4. (Another issue with the current implementation: filtering courses based on the search input and re-rendering based on scrolling is happening in the same step, `updateCourseSearchResults`.  That's inefficient, since it means that the courses are getting re-filtered unnecessarily every time the course list is scrolled; they should be re-filtered only when the search input changes.)

As the name implies, _infinite_ scrollers are meant for _infinite_ data (or at least data where you don't readily know how much total stuff there is); in those situations, it makes sense that you can't estimate the total length or skip to the end, because you _don't know_ the total length or the end!  The good news is, we have _finite_ data, so we can use a different rendering technique, termed by some a "virtualized list".  Here's how it works:
- Render a single dummy list item on DOM load, and measure its height.
- Compute the total height of all list items (number of items * height of individual items).  Insert a blank background overlay/placeholder (`courseSearchResultsPlaceholder`) into the scroll container (`courseSearchResults`) so that it has the correct scroll height.
- On each scroll event (and the initial render), calculate, based on the scroll position, window viewport height, and the height of individual items, the indices of items that would be visible on the screen (and some additional few above and below, for padding).  Calculate their positions, and render _only those items_ to the screen, with the correct absolute positions set.
- The resulting effect is that the scroller _simulates the entire list_ being rendered, because it has the correct scroll height, while in fact _improving on_ the performance of lazy scroll rendering, because it always renders to the DOM only a small, fixed-size subset (~60 or so) of the list items instead of increasing the subset with the scroll position (causing performance to deteriorate as you scroll down).  Wow; the best of both worlds!

A key observation as to why this technique works is that, currently, the performance bottleneck largely lies in having a cluttered DOM (and not network loading speeds, or in-memory data stores).  From my experience, I've found that the app starts to feel laggy as soon as you have ~1k course entity items _rendered to DOM_.  When fewer elements are rendered to DOM, even if we had ~10k course objects in our API data, the performance would still be fairly snappy.  Thus, by reducing the DOM size, this technique dramatically improves UI performance.

Here's how this PR fixes each one of the above mentioned limitations with the current approach:
1. Janky scrollbars are not an issue anymore, because the scroll height is calculated correctly once and does not vary throughout scrolling, so the scrollbar is an accurate, meaningful reflection of the actual scroll heights and positions.

  ![hyperschedule-scroll-virtual-nice](https://user-images.githubusercontent.com/3887189/63645757-adb2b200-c6f4-11e9-8506-75e6ba491b46.gif)

2. The number of elements rendered varies not with scroll position but the height of the viewport, so the same (small) number of elements is rendered regardless of where you scroll.  Hence scrolling down causes no performance deterioration.

  ![hyperschedule-scroll-virtual-no-deterioration](https://user-images.githubusercontent.com/3887189/63645758-b1463900-c6f4-11e9-8ff5-3d89977c5f57.gif)

3. The entire list rendering logic has been redone.  It is now actually much simpler to reason about and hence less bug-prone.  As a side effect, the duplicate courses bug is no more.
4. This implementation splits up re-rendering (on window resize, list scroll events) and re-filtering (on search change), and only re-filters when necessary.

