### PR TITLE
Implement "days:" Filter (Issue #130)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -442,6 +442,10 @@
                 <span class="modal-input-text">col</span>: filter by college
                 (e.g. HM, SC)
               </li>
+              <li>
+                <span class="modal-input-text">days</span>: filter by class meeting days
+                (e.g. M, TR, MWF)
+              </li>
             </ul>
             <p>
               Click on the <b>+</b> button to add a course. Each section is

--- a/src/index.html
+++ b/src/index.html
@@ -444,7 +444,7 @@
               </li>
               <li>
                 <span class="modal-input-text">days</span>: filter by class
-                meeting days (e.g. M, TR, MWF)
+                meeting days (e.g. M, =TR, <=MWF, >MW)
               </li>
             </ul>
             <p>

--- a/src/index.html
+++ b/src/index.html
@@ -443,8 +443,8 @@
                 (e.g. HM, SC)
               </li>
               <li>
-                <span class="modal-input-text">days</span>: filter by class meeting days
-                (e.g. M, TR, MWF)
+                <span class="modal-input-text">days</span>: filter by class
+                meeting days (e.g. M, TR, MWF)
               </li>
             </ul>
             <p>

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -27,6 +27,8 @@ const filterKeywords = {
   "days:": ["days:", "day:"]
 };
 
+filterInequalities = ["<=", ">=", "<", ">", "="];
+
 //// DOM elements
 
 const courseSearchToggle = document.getElementById("course-search-toggle");
@@ -550,12 +552,6 @@ function coursePassesTextFilters(course, textFilters) {
   return true;
 }
 
-filterInequalities = ["<=", ">=", "<", ">", "="];
-
-function displaySet(s) {
-  s.forEach(console.log, s);
-}
-
 function parseDaysInequality(inputDays) {
   for (const rel of filterInequalities)
     if (inputDays.startsWith(rel)) return rel;
@@ -589,12 +585,15 @@ function coursePassesDayFilter(course, inputString) {
   );
 
   switch (rel) {
-    case "<=": // courseDays is a subset of inputDays
+    case "<=":
+      // courseDays is a subset of inputDays
       return courseDays.subSet(inputDays);
     case "":
-    case ">=": // inputDays is a subset of courseDays
+    case ">=":
+      // inputDays is a subset of courseDays
       return inputDays.subSet(courseDays);
-    case "=": // inputDays match exactly courseDays
+    case "=":
+      // inputDays match exactly courseDays
       const difference1 = new Set(
         [...courseDays].filter(x => !inputDays.has(x))
       );
@@ -602,9 +601,11 @@ function coursePassesDayFilter(course, inputString) {
         [...inputDays].filter(x => !courseDays.has(x))
       );
       return difference1.size == 0 && difference2.size == 0;
-    case "<": // courseDays is a proper subset of inputDays
+    case "<":
+      // courseDays is a proper subset of inputDays
       return courseDays.subSet(inputDays) && inputDays.size != courseDays.size;
-    case ">": // inputDays is a proper subset of courseDays
+    case ">":
+      // inputDays is a proper subset of courseDays
       return inputDays.subSet(courseDays) && inputDays.size != courseDays.size;
     default:
       return false;

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -552,8 +552,6 @@ function coursePassesTextFilters(course, textFilters) {
     return false;
   }
 
-  
-
   return true;
 }
 

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -23,7 +23,8 @@ const greyConflictCoursesOptions = ["none", "starred", "all"];
 
 const filterKeywords = {
   "dept:": ["dept:", "department:"],
-  "college:": ["college", "col:", "school:", "sch:"]
+  "college:": ["college", "col:", "school:", "sch:"],
+  "days:": ["days:", "day:"]
 };
 
 //// DOM elements
@@ -536,13 +537,23 @@ function coursePassesTextFilters(course, textFilters) {
   const lowerCourseCode = course.courseCode.toLowerCase();
   const dept = lowerCourseCode.split(" ")[0];
   const col = lowerCourseCode.split(" ")[2].split("-")[0];
+  const scheduleList = course.courseSchedule;
+  let days = "";
+
+  for (let schedule of scheduleList) {
+    days += schedule.scheduleDays.toLowerCase();
+  }
 
   if (
     (textFilters["dept:"] && !dept.match(textFilters["dept:"])) ||
-    (textFilters["college:"] && !col.match(textFilters["college:"]))
+    (textFilters["college:"] && !col.match(textFilters["college:"])) ||
+    (textFilters["days:"] && !days.match(textFilters["days:"]))
   ) {
     return false;
   }
+
+  
+
   return true;
 }
 


### PR DESCRIPTION
Implements a new course search keyword filter "day:" that allows users to filter courses by day of the week:
<img width="1322" alt="newcoursesearch" src="https://user-images.githubusercontent.com/44514614/75615675-b8af2a80-5afb-11ea-99ab-ac6c0421a3ba.png">

The help modal was also changed to explain the new feature:
<img width="495" alt="helpmodal" src="https://user-images.githubusercontent.com/44514614/75615668-ab923b80-5afb-11ea-865e-0e9f693537ac.png">

This is part of CS121 Group 2. Team members include @JeremyTsaii, @godpng, @rory6103.
