### PR TITLE
Implement RateMyProfessor Links (Issue #134)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -451,7 +451,13 @@
               Click on the <b>+</b> button to add a course. Each section is
               listed separately, so make sure to get all the ones you want. You
               can click on a course to see more information about it in the
-              upper-right panel.
+              upper-right panel. Notice that professor names are highlighted
+              blue to indicate an embedded link. Clicking on the link will take
+              you to RateMyProfessors with the professor's name in the search
+              query. This is to provide easier access to professor ratings in
+              case you are curious about what other students have to say about a
+              specific professor, but take them with a grain of salt because
+              reviews are anonymously submitted.
             </p>
             <p>
               On the right-hand column, you can click and drag courses to

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -454,8 +454,6 @@ function generateCourseDescription(course) {
   const instructors = formatList(course.courseInstructors);
   description.push(instructors);
 
-  const urlAarr = generateRateMyP(course.courseInstructors);
-
   let partOfYear;
   if (_.isEmpty(course.courseSchedule)) {
     partOfYear = "No scheduled meetings";
@@ -1362,6 +1360,7 @@ function setCourseDescriptionBox(course) {
     courseDescriptionBox.removeChild(courseDescriptionBox.lastChild);
   }
   const description = generateCourseDescription(course);
+
   for (let idx = 0; idx < description.length; ++idx) {
     const line = description[idx];
     if (idx !== 0) {
@@ -1369,15 +1368,32 @@ function setCourseDescriptionBox(course) {
     }
     const paragraph = document.createElement("p");
     const text = document.createTextNode(line);
-    paragraph.appendChild(text);
+
+    let offset = 4;
+    if (course.courseDescription == null) offset--;
+    if (idx == description.length - offset) {
+      injectLinks(course, paragraph);
+    } else {
+      paragraph.appendChild(text);
+    }
+
     courseDescriptionBox.appendChild(paragraph);
   }
   minimizeArrowPointUp();
-  injectLinks();
   courseDescriptionVisible();
 }
 
-function injectLinks() {}
+function injectLinks(course, paragraph) {
+  const urlArr = generateRateMyP(course.courseInstructors);
+  const nameArr = course.courseInstructors;
+  let linkList = [];
+  for (let i = 0; i < nameArr.length; i++) {
+    let profLink = nameArr[i];
+    profLink = profLink.link(urlArr[i]);
+    linkList.push(profLink);
+  }
+  paragraph.innerHTML = formatList(linkList);
+}
 
 function minimizeCourseDescription() {
   if (

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -427,6 +427,19 @@ function termListDescription(terms, termCount) {
   return _.capitalize(`${formatList(numbers)} ${qualifier}-semester course`);
 }
 
+function generateRateMyP(instructors) {
+  urlArr = [];
+  for (const prof of instructors) {
+    const nameArr = prof.split(",");
+    const last = nameArr[0];
+    const first = nameArr[1].split(" ")[1];
+    const url =
+      "https://www.ratemyprofessors.com/search.jsp?query=" + first + "+" + last;
+    urlArr.push(url);
+  }
+  return urlArr;
+}
+
 function generateCourseDescription(course) {
   const description = [];
 
@@ -440,6 +453,8 @@ function generateCourseDescription(course) {
 
   const instructors = formatList(course.courseInstructors);
   description.push(instructors);
+
+  const urlAarr = generateRateMyP(course.courseInstructors);
 
   let partOfYear;
   if (_.isEmpty(course.courseSchedule)) {
@@ -1358,8 +1373,11 @@ function setCourseDescriptionBox(course) {
     courseDescriptionBox.appendChild(paragraph);
   }
   minimizeArrowPointUp();
+  injectLinks();
   courseDescriptionVisible();
 }
+
+function injectLinks() {}
 
 function minimizeCourseDescription() {
   if (

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -428,7 +428,7 @@ function termListDescription(terms, termCount) {
 }
 
 function generateRateMyP(instructors) {
-  urlArr = [];
+  let urlArr = [];
   for (const prof of instructors) {
     if (prof == "Staff") {
       urlArr.push("Staff");
@@ -1374,13 +1374,12 @@ function setCourseDescriptionBox(course) {
     const text = document.createTextNode(line);
 
     let offset = 4;
-    if (course.courseDescription == null) offset--;
-    if (idx == description.length - offset) {
+    if (course.courseDescription === null) offset--;
+    if (idx === description.length - offset) {
       injectLinks(course, paragraph);
     } else {
       paragraph.appendChild(text);
     }
-
     courseDescriptionBox.appendChild(paragraph);
   }
   minimizeArrowPointUp();
@@ -1392,7 +1391,7 @@ function injectLinks(course, paragraph) {
   const nameArr = course.courseInstructors;
   let linkList = [];
   for (let i = 0; i < nameArr.length; i++) {
-    if (nameArr[i] != "Staff") {
+    if (nameArr[i] !== "Staff") {
       let profLink = nameArr[i];
       profLink = profLink.link(urlArr[i]);
       linkList.push(profLink);

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -430,6 +430,10 @@ function termListDescription(terms, termCount) {
 function generateRateMyP(instructors) {
   urlArr = [];
   for (const prof of instructors) {
+    if (prof == "Staff") {
+      urlArr.push("Staff");
+      continue;
+    }
     const nameArr = prof.split(",");
     const last = nameArr[0];
     const first = nameArr[1].split(" ")[1];
@@ -1388,11 +1392,21 @@ function injectLinks(course, paragraph) {
   const nameArr = course.courseInstructors;
   let linkList = [];
   for (let i = 0; i < nameArr.length; i++) {
-    let profLink = nameArr[i];
-    profLink = profLink.link(urlArr[i]);
-    linkList.push(profLink);
+    if (nameArr[i] != "Staff") {
+      let profLink = nameArr[i];
+      profLink = profLink.link(urlArr[i]);
+      linkList.push(profLink);
+    } else {
+      linkList.push(nameArr[i]);
+    }
   }
   paragraph.innerHTML = formatList(linkList);
+  for (let child of paragraph.childNodes) {
+    if (child.nodeName === "A") {
+      child.target = "_blank";
+      child.rel = "noopener noreferrer";
+    }
+  }
 }
 
 function minimizeCourseDescription() {


### PR DESCRIPTION
Implements the ability for users to click on professor names in the course description box and have a new tab open to RateMyProfessors with the professor's name as the search query. In future implementations, could possible advance this by making the link go to the professor's actual RMP page or have a popup display the professor's data without having to go to a new tab.

![image](https://user-images.githubusercontent.com/44514622/79398578-df071900-7f35-11ea-9ef2-f81dcb55373e.png)

![image](https://user-images.githubusercontent.com/44514622/79398584-e4fcfa00-7f35-11ea-85f3-5ffb38a58ccd.png)

Also updates the help modal to inform users of where the links take them and how they should understand RMP takes anonymous reviews.

![image](https://user-images.githubusercontent.com/44514622/79398607-f0502580-7f35-11ea-9df4-f1b82c3d9776.png)

This is part of CS121 Group 2. Team members include @JeremyTsaii, @godpng, @rory6103.