### PR TITLE
Upgrade from Disco to Eoan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG UID
 


### PR DESCRIPTION
I hit this error in one of my other projects so I figured I would save you some time debugging @kwshi. Apparently as soon as Ubuntu drops official support for a release, they immediately brick the package manager. I... don't really know what to say to that.

On the one hand, using an LTS release would fix this from happening. On the other hand, the LTS releases have _really_ old software. Not sure if there's a good solution.