### PR TITLE
Multiple Schedules (Issue #140)

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -75,11 +75,12 @@ body {
 }
 
 #course-search-schedule-toggle-bar {
-  margin: 1rem 0 1rem 1rem;
+  margin: 1rem 0 0 1rem;
 }
 
 #course-schedules-buttons-bar {
   margin: 1rem 0 1rem 1rem;
+  padding: 0 0;
   justify-content: space-around;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -78,10 +78,25 @@ body {
   margin: 1rem 0 1rem 1rem;
 }
 
+#course-schedules-buttons-bar {
+  margin: 1rem 0 1rem 1rem;
+}
+
 #course-search-toggle-wrapper,
 #schedule-toggle-wrapper {
   flex-grow: 1;
   flex-basis: 0;
+}
+
+#schedule-1-wrapper,
+#schedule-2-wrapper,
+#schedule-3-wrapper,
+#schedule-4-wrapper {
+  flex-grow: 1;
+  flex-basis: 0;
+  display: block;
+  margin: 0 auto;
+  width: 100%;
 }
 
 #course-search-toggle {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -126,7 +126,7 @@ body {
 }
 
 .schedule-label {
-  margin: 0em .5em;
+  margin: 0em 0.5em;
 }
 
 #course-schedules-buttons-bar {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -78,22 +78,8 @@ body {
   margin: 1rem 0 0 1rem;
 }
 
-#course-schedules-buttons-bar {
-  margin: 1rem 0 1rem 1rem;
-  padding: 0 0;
-  justify-content: space-around;
-}
-
 #course-search-toggle-wrapper,
 #schedule-toggle-wrapper {
-  flex-grow: 1;
-  flex-basis: 0;
-}
-
-#schedule1,
-#schedule2,
-#schedule3,
-#schedule4 {
   flex-grow: 1;
   flex-basis: 0;
 }
@@ -123,6 +109,38 @@ body {
 
 #schedule-column.hidden {
   display: none;
+}
+
+/** Multiple schedules buttons **/
+
+.course-schedule-button-content {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+.schedule-checkbox {
+  flex-grow: 0;
+  flex-basis: 0;
+  display: none;
+}
+
+.schedule-label {
+  margin: 0em .5em;
+}
+
+#course-schedules-buttons-bar {
+  margin: 1rem 0 1rem 1rem;
+  padding: 0 0;
+  justify-content: space-around;
+}
+
+#schedule1,
+#schedule2,
+#schedule3,
+#schedule4 {
+  flex-grow: 1;
+  flex-basis: 0;
 }
 
 /** Course search **/

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -80,6 +80,7 @@ body {
 
 #course-schedules-buttons-bar {
   margin: 1rem 0 1rem 1rem;
+  justify-content: space-around;
 }
 
 #course-search-toggle-wrapper,
@@ -88,15 +89,12 @@ body {
   flex-basis: 0;
 }
 
-#schedule-1-wrapper,
-#schedule-2-wrapper,
-#schedule-3-wrapper,
-#schedule-4-wrapper {
+#schedule1,
+#schedule2,
+#schedule3,
+#schedule4 {
   flex-grow: 1;
   flex-basis: 0;
-  display: block;
-  margin: 0 auto;
-  width: 100%;
 }
 
 #course-search-toggle {

--- a/src/index.html
+++ b/src/index.html
@@ -63,32 +63,40 @@
       <div id="course-schedules-buttons-bar" class="toolbar">
         <div class="course-schedule-button-content btn" id="schedule1">
           <label id="schedule1-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
+            <input type="checkbox" class="schedule-checkbox" />
+            <i
+              class="schedule-icon icon ion-android-checkbox-outline-blank"
+            ></i>
           </label>
           Schedule1
         </div>
         <div class="course-schedule-button-content btn" id="schedule2">
           <label id="schedule2-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
+            <input type="checkbox" class="schedule-checkbox" />
+            <i
+              class="schedule-icon icon ion-android-checkbox-outline-blank"
+            ></i>
           </label>
           Schedule2
         </div>
         <div class="course-schedule-button-content btn" id="schedule3">
           <label id="schedule3-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
+            <input type="checkbox" class="schedule-checkbox" />
+            <i
+              class="schedule-icon icon ion-android-checkbox-outline-blank"
+            ></i>
           </label>
           Schedule3
         </div>
         <div class="course-schedule-button-content btn" id="schedule4">
           <label id="schedule4-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
+            <input type="checkbox" class="schedule-checkbox" />
+            <i
+              class="schedule-icon icon ion-android-checkbox-outline-blank"
+            ></i>
           </label>
           Schedule4
-        </div>       
+        </div>
       </div>
       <div id="course-search-column">
         <div id="course-search-bar" class="toolbar">

--- a/src/index.html
+++ b/src/index.html
@@ -61,17 +61,34 @@
         </div>
       </div>
       <div id="course-schedules-buttons-bar" class="toolbar">
-          <button type="button" id="schedule1" class="btn">
-            schedule1
-          </button>
-          <button type="button" id="schedule2" class="btn">
-            schedule2
-          </button>
-          <button type="button" id="schedule3" class="btn">
-            schedule3
-          </button>
-          <button type="button" id="schedule4" class="btn">
-            schedule4
+        <div class="course-schedule-button-content btn" id="schedule1">
+          <label id="schedule1-checkbox" class="schedule-label">
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox"></i>
+          </label>
+          Schedule1
+        </div>
+        <div class="course-schedule-button-content btn" id="schedule2">
+          <label id="schedule2-checkbox" class="schedule-label">
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox"></i>
+          </label>
+          Schedule2
+        </div>
+        <div class="course-schedule-button-content btn" id="schedule3">
+          <label id="schedule3-checkbox" class="schedule-label">
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox"></i>
+          </label>
+          Schedule3
+        </div>
+        <div class="course-schedule-button-content btn" id="schedule4">
+          <label id="schedule4-checkbox" class="schedule-label">
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox"></i>
+          </label>
+          Schedule4
+        </div>       
       </div>
       <div id="course-search-column">
         <div id="course-search-bar" class="toolbar">

--- a/src/index.html
+++ b/src/index.html
@@ -486,7 +486,8 @@
               </li>
             </ul>
             <p>
-              Click on the <b>+</b> button to add a course. Each section is
+              Click on the <b>+</b> button to add a course. The course will be
+              added to all schedules with a check next to them. Each section is
               listed separately, so make sure to get all the ones you want. You
               can click on a course to see more information about it in the
               upper-right panel.
@@ -505,7 +506,10 @@
               algorithm starts from the top of your list and goes down. Courses
               that are disabled, however, won't be considered. So, to change
               your schedule, just use reordering, starring, and disabling,
-              rather than paging through multiple schedules.
+              rather than paging through multiple schedules. View your different
+              schedules on the calendar interface one at at time by clicking on
+              the schedule tabs below the <b>Course Search</b> and
+              <b>Schedule</b> tabs.
             </p>
             <p>
               Hyperschedule was created by Radon Rosborough

--- a/src/index.html
+++ b/src/index.html
@@ -60,6 +60,28 @@
           </button>
         </div>
       </div>
+      <div id="course-schedules-buttons-bar" class="toolbar">
+        <div id="schedule-1-wrapper">
+          <button type="button" id="schedule1" class="btn">
+            schedule1
+          </button>
+        </div>
+        <div id="schedule-2-wrapper">
+          <button type="button" id="schedule2" class="btn">
+            schedule2
+          </button>
+        </div>
+        <div id="schedule-3-wrapper">
+          <button type="button" id="schedule3" class="btn">
+            schedule3
+          </button>
+        </div>
+        <div id="schedule-4-wrapper">
+          <button type="button" id="schedule4" class="btn">
+            schedule4
+          </button>
+        </div>
+      </div>
       <div id="course-search-column">
         <div id="course-search-bar" class="toolbar">
           <input

--- a/src/index.html
+++ b/src/index.html
@@ -63,7 +63,7 @@
       <div id="course-schedules-buttons-bar" class="toolbar">
         <div class="course-schedule-button-content btn" id="schedule1">
           <label id="schedule1-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
+            <input type="checkbox" class="schedule-checkbox" checked="true"/>
             <i class="schedule-icon icon ion-android-checkbox"></i>
           </label>
           Schedule1
@@ -71,21 +71,21 @@
         <div class="course-schedule-button-content btn" id="schedule2">
           <label id="schedule2-checkbox" class="schedule-label">
             <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox"></i>
+            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
           </label>
           Schedule2
         </div>
         <div class="course-schedule-button-content btn" id="schedule3">
           <label id="schedule3-checkbox" class="schedule-label">
             <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox"></i>
+            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
           </label>
           Schedule3
         </div>
         <div class="course-schedule-button-content btn" id="schedule4">
           <label id="schedule4-checkbox" class="schedule-label">
             <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox"></i>
+            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
           </label>
           Schedule4
         </div>       

--- a/src/index.html
+++ b/src/index.html
@@ -63,8 +63,8 @@
       <div id="course-schedules-buttons-bar" class="toolbar">
         <div class="course-schedule-button-content btn" id="schedule1">
           <label id="schedule1-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox" checked="true"/>
-            <i class="schedule-icon icon ion-android-checkbox"></i>
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
           </label>
           Schedule1
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -61,26 +61,17 @@
         </div>
       </div>
       <div id="course-schedules-buttons-bar" class="toolbar">
-        <div id="schedule-1-wrapper">
           <button type="button" id="schedule1" class="btn">
             schedule1
           </button>
-        </div>
-        <div id="schedule-2-wrapper">
           <button type="button" id="schedule2" class="btn">
             schedule2
           </button>
-        </div>
-        <div id="schedule-3-wrapper">
           <button type="button" id="schedule3" class="btn">
             schedule3
           </button>
-        </div>
-        <div id="schedule-4-wrapper">
           <button type="button" id="schedule4" class="btn">
             schedule4
-          </button>
-        </div>
       </div>
       <div id="course-search-column">
         <div id="course-search-bar" class="toolbar">

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1491,14 +1491,16 @@ function addToSchedules(course) {
   for (const schedule of gSchedulesSelected) {
     if (schedule !== gLastScheduleSelected) {
       let oldSchedule = readFromLocalStorage(
-        `schedulesSelected${schedule}`,
+        `selectedCourses${schedule}`,
         _.isArray,
         []
       );
-      console.log(oldSchedule);
       if (!courseAlreadyAdded(course, oldSchedule)) {
         oldSchedule.push(course);
-        localStorage.setItem(`schedulesSelected${schedule}`, oldSchedule);
+        localStorage.setItem(
+          `selectedCourses${schedule}`,
+          JSON.stringify(oldSchedule)
+        );
       }
     }
   }
@@ -1626,6 +1628,18 @@ function checkSchedule() {
     event.target.className === "course-schedule-button-content btn btn-light" ||
     event.target.className === "course-schedule-button-content btn btn-info"
   ) {
+    // Uncheck previously selected schedule
+    if (gSchedulesSelected.includes(gLastScheduleSelected)) {
+      gSchedulesSelected.splice(
+        gSchedulesSelected.indexOf(gLastScheduleSelected),
+        1
+      );
+      const checkBox = document.getElementsByClassName(
+        "schedule-icon icon ion-android-checkbox"
+      )[0];
+      checkBox.classList.remove("ion-android-checkbox");
+      checkBox.classList.add("ion-android-checkbox-outline-blank");
+    }
     gLastScheduleSelected = Number(event.target.id.charAt(8));
     gSelectedCourses = upgradeSelectedCourses(
       readFromLocalStorage(
@@ -1634,6 +1648,14 @@ function checkSchedule() {
         []
       )
     );
+    // Check if not already checked
+    console.log(event.target.children[0].children[1]);
+    if (!gSchedulesSelected.includes(gLastScheduleSelected)) {
+      gSchedulesSelected.push(gLastScheduleSelected);
+      const checkBox = event.target.children[0].children[1];
+      checkBox.classList.remove("ion-android-checkbox-outline-blank");
+      checkBox.classList.add("ion-android-checkbox");
+    }
 
     updateCourseDisplays();
     setScheduleSelected();

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1210,6 +1210,14 @@ function getSearchTextFilters(filtersTextArray) {
 //// DOM updates
 ///// DOM updates due to global state change
 
+function updateScheduleSelectedStartup() {
+  let schedule = document.getElementById("schedule" + gLastScheduleSelected);
+  let schedArr = schedule.children[0].children;
+  schedArr[0].checked = true;
+  schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
+  schedArr[1].classList.add("ion-android-checkbox");
+}
+
 function updateTabToggle() {
   setEntityVisibility(scheduleColumn, gScheduleTabSelected);
   setButtonSelected(scheduleToggle, gScheduleTabSelected);
@@ -1573,7 +1581,6 @@ function toggleScheduleSelected() {
     for (let l of document.getElementsByClassName("schedule-checkbox")) {
       if (l.checked) numChecked++;
     }
-    console.log(numChecked);
     if (numChecked >= 1) {
       schedArr[1].classList.remove("ion-android-checkbox");
       schedArr[1].classList.add("ion-android-checkbox-outline-blank");
@@ -2199,6 +2206,7 @@ readStateFromLocalStorage();
 handleGlobalStateUpdate();
 setScheduleSelected();
 retrieveCourseDataUntilSuccessful();
+updateScheduleSelectedStartup();
 
 /// Closing remarks
 

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -34,6 +34,11 @@ filterInequalities = ["<=", ">=", "<", ">", "="];
 const courseSearchToggle = document.getElementById("course-search-toggle");
 const scheduleToggle = document.getElementById("schedule-toggle");
 
+const schedule1 = document.getElementById("schedule1");
+const schedule2 = document.getElementById("schedule2");
+const schedule3 = document.getElementById("schedule3");
+const schedule4 = document.getElementById("schedule4");
+
 const closedCoursesToggle = document.getElementById("closed-courses-toggle");
 const hideAllConflictingCoursesToggle = document.getElementById(
   "all-conflicting-courses-toggle"
@@ -110,6 +115,8 @@ const importExportCopyButton = document.getElementById(
 let gApiData = null;
 let gSelectedCourses = [];
 let gScheduleTabSelected = false;
+let gLastScheduleSelected = 1;
+let gSchedulesSelected = [0];
 let gShowClosedCourses = true;
 let gHideAllConflictingCourses = false;
 let gHideStarredConflictingCourses = false;
@@ -818,6 +825,10 @@ function attachListeners() {
 
   courseSearchToggle.addEventListener("click", displayCourseSearchColumn);
   scheduleToggle.addEventListener("click", displayScheduleColumn);
+  schedule1.addEventListener("click", checkSchedule1);
+  schedule2.addEventListener("click", checkSchedule2);
+  schedule3.addEventListener("click", checkSchedule3);
+  schedule4.addEventListener("click", checkSchedule4);
   closedCoursesToggle.addEventListener("click", toggleClosedCourses);
   hideAllConflictingCoursesToggle.addEventListener(
     "click",
@@ -1532,6 +1543,22 @@ function displayScheduleColumn() {
   gScheduleTabSelected = true;
   updateTabToggle();
   writeStateToLocalStorage();
+}
+
+function checkSchedule1() {
+  console.log("schedule 1 clicked");
+}
+
+function checkSchedule2() {
+  console.log("schedule 2 clicked");
+}
+
+function checkSchedule3() {
+  console.log("schedule 3 clicked");
+}
+
+function checkSchedule4() {
+  console.log("schedule 4 clicked");
 }
 
 //// Course retrieval

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1452,7 +1452,22 @@ function addCourse(course) {
   course.selected = true;
   course.starred = false;
   gSelectedCourses.push(course);
+  addToSchedules(course);
   handleSelectedCoursesUpdate();
+}
+
+function addToSchedules(course) {
+  for (const schedule of gSchedulesSelected) {
+    if (schedule !== gLastScheduleSelected) {
+      let oldSchedule = readFromLocalStorage(
+        `schedulesSelected${schedule}`,
+        _.isArray,
+        []
+      );
+      oldSchedule.push(course);
+      localStorage.setItem(`schedulesSelected${schedule}`, oldSchedule);
+    }
+  }
 }
 
 function removeCourse(course) {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -334,6 +334,22 @@ function setButtonSelected(button, selected) {
   button.classList.remove(classRemoved);
 }
 
+function setScheduleSelected() {
+  const schedSelected = "btn-info";
+  const schedInactive = "btn-light";
+  let i;
+  for (i = 1; i <= 4; i++) {
+    let button = document.getElementById("schedule" + i);
+    if (i == gLastScheduleSelected) {
+      button.classList.add(schedSelected);
+      button.classList.remove(schedInactive);
+    } else {
+      button.classList.add(schedInactive);
+      button.classList.remove(schedSelected);
+    }
+  }
+}
+
 function removeEntityChildren(entity) {
   while (entity.hasChildNodes()) {
     entity.removeChild(entity.lastChild);
@@ -1582,6 +1598,8 @@ function checkSchedule() {
 
   updateCourseDisplays();
 
+  setScheduleSelected();
+
   writeStateToLocalStorage();
 }
 
@@ -2149,6 +2167,7 @@ function downloadICalFile() {
 attachListeners();
 readStateFromLocalStorage();
 handleGlobalStateUpdate();
+setScheduleSelected();
 retrieveCourseDataUntilSuccessful();
 
 /// Closing remarks

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -113,10 +113,10 @@ const importExportCopyButton = document.getElementById(
 
 // Persistent data.
 let gApiData = null;
+let gLastScheduleSelected = 1;
+let gSchedulesSelected = [1];
 let gSelectedCourses = [];
 let gScheduleTabSelected = false;
-let gLastScheduleSelected = 1;
-let gSchedulesSelected = [0];
 let gShowClosedCourses = true;
 let gHideAllConflictingCourses = false;
 let gHideStarredConflictingCourses = false;
@@ -825,10 +825,10 @@ function attachListeners() {
 
   courseSearchToggle.addEventListener("click", displayCourseSearchColumn);
   scheduleToggle.addEventListener("click", displayScheduleColumn);
-  schedule1.addEventListener("click", checkSchedule1);
-  schedule2.addEventListener("click", checkSchedule2);
-  schedule3.addEventListener("click", checkSchedule3);
-  schedule4.addEventListener("click", checkSchedule4);
+  schedule1.addEventListener("click", checkSchedule);
+  schedule2.addEventListener("click", checkSchedule);
+  schedule3.addEventListener("click", checkSchedule);
+  schedule4.addEventListener("click", checkSchedule);
   closedCoursesToggle.addEventListener("click", toggleClosedCourses);
   hideAllConflictingCoursesToggle.addEventListener(
     "click",
@@ -1545,20 +1545,29 @@ function displayScheduleColumn() {
   writeStateToLocalStorage();
 }
 
-function checkSchedule1() {
-  console.log("schedule 1 clicked");
-}
+function checkSchedule() {
+  const id = event.target.id;
+  if (id === "schedule1") {
+    gLastScheduleSelected = 1;
+  } else if (id === "schedule2") {
+    gLastScheduleSelected = 2;
+  } else if (id === "schedule3") {
+    gLastScheduleSelected = 3;
+  } else if (id === "schedule4") {
+    gLastScheduleSelected = 4;
+  }
 
-function checkSchedule2() {
-  console.log("schedule 2 clicked");
-}
+  gSelectedCourses = upgradeSelectedCourses(
+    readFromLocalStorage(
+      `selectedCourses${gLastScheduleSelected}`,
+      _.isArray,
+      []
+    )
+  );
 
-function checkSchedule3() {
-  console.log("schedule 3 clicked");
-}
+  updateCourseDisplays();
 
-function checkSchedule4() {
-  console.log("schedule 4 clicked");
+  writeStateToLocalStorage();
 }
 
 //// Course retrieval
@@ -1670,7 +1679,12 @@ async function retrieveCourseDataUntilSuccessful() {
 
 function writeStateToLocalStorage() {
   localStorage.setItem("apiData", JSON.stringify(gApiData));
-  localStorage.setItem("selectedCourses", JSON.stringify(gSelectedCourses));
+  localStorage.setItem("lastScheduleSelected", gLastScheduleSelected);
+  localStorage.setItem("schedulesSelected", gSchedulesSelected);
+  localStorage.setItem(
+    `selectedCourses${gLastScheduleSelected}`,
+    JSON.stringify(gSelectedCourses)
+  );
   localStorage.setItem("scheduleTabSelected", gScheduleTabSelected);
   localStorage.setItem("showClosedCourses", gShowClosedCourses);
   localStorage.setItem("hideAllConflictingCourses", gHideAllConflictingCourses);
@@ -1750,8 +1764,20 @@ function upgradeSelectedCourses(selectedCourses) {
 
 function readStateFromLocalStorage() {
   gApiData = readFromLocalStorage("apiData", _.isObject, null);
+  gLastScheduleSelected = readFromLocalStorage(
+    "lastScheduleSelected",
+    _.isNumber,
+    1
+  );
+  gSchedulesSelected = readFromLocalStorage("schedulesSelected", _.isArray, [
+    1
+  ]);
   gSelectedCourses = upgradeSelectedCourses(
-    readFromLocalStorage("selectedCourses", _.isArray, [])
+    readFromLocalStorage(
+      `selectedCourses${gLastScheduleSelected}`,
+      _.isArray,
+      []
+    )
   );
   gScheduleTabSelected = readFromLocalStorage(
     "scheduleTabSelected",

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -848,7 +848,7 @@ function attachListeners() {
   schedule3.addEventListener("click", checkSchedule);
   schedule4.addEventListener("click", checkSchedule);
 
-  for (let label of scheduleLabels) {
+  for (const label of scheduleLabels) {
     label.addEventListener("change", toggleScheduleSelected);
   }
 
@@ -1211,8 +1211,8 @@ function getSearchTextFilters(filtersTextArray) {
 ///// DOM updates due to global state change
 
 function updateScheduleSelectedStartup() {
-  let schedule = document.getElementById("schedule" + gLastScheduleSelected);
-  let schedArr = schedule.children[0].children;
+  const schedule = document.getElementById("schedule" + gLastScheduleSelected);
+  const schedArr = schedule.children[0].children;
   schedArr[0].checked = true;
   schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
   schedArr[1].classList.add("ion-android-checkbox");
@@ -1574,11 +1574,11 @@ function toggleCourseStarred(course) {
 }
 
 function toggleScheduleSelected() {
-  let schedArr = event.target.parentNode.children;
+  const schedArr = event.target.parentNode.children;
   if (schedArr[1].classList.contains("ion-android-checkbox")) {
     // Check first that at least one other schedule is still checked
     let numChecked = 0;
-    for (let l of document.getElementsByClassName("schedule-checkbox")) {
+    for (const l of document.getElementsByClassName("schedule-checkbox")) {
       if (l.checked) numChecked++;
     }
     if (numChecked >= 1) {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -362,7 +362,7 @@ function removeEntityChildren(entity) {
 ///// Course property queries
 
 function isCourseClosed(course) {
-  return course.courseEnrollmentStatus == "closed";
+  return course.courseEnrollmentStatus === "closed";
 }
 
 function courseToString(course) {
@@ -625,13 +625,13 @@ function coursePassesDayFilter(course, inputString) {
       const difference2 = new Set(
         [...inputDays].filter(x => !courseDays.has(x))
       );
-      return difference1.size == 0 && difference2.size == 0;
+      return difference1.size === 0 && difference2.size === 0;
     case "<":
       // courseDays is a proper subset of inputDays
-      return courseDays.subSet(inputDays) && inputDays.size != courseDays.size;
+      return courseDays.subSet(inputDays) && inputDays.size !== courseDays.size;
     case ">":
       // inputDays is a proper subset of courseDays
-      return inputDays.subSet(courseDays) && inputDays.size != courseDays.size;
+      return inputDays.subSet(courseDays) && inputDays.size !== courseDays.size;
     default:
       return false;
   }
@@ -1640,6 +1640,8 @@ function checkSchedule() {
       checkBox.classList.remove("ion-android-checkbox");
       checkBox.classList.add("ion-android-checkbox-outline-blank");
     }
+
+    // Switch current schedule
     gLastScheduleSelected = Number(event.target.id.charAt(8));
     gSelectedCourses = upgradeSelectedCourses(
       readFromLocalStorage(
@@ -1648,8 +1650,8 @@ function checkSchedule() {
         []
       )
     );
+
     // Check if not already checked
-    console.log(event.target.children[0].children[1]);
     if (!gSchedulesSelected.includes(gLastScheduleSelected)) {
       gSchedulesSelected.push(gLastScheduleSelected);
       const checkBox = event.target.children[0].children[1];

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -795,10 +795,10 @@ function computeCreditCountDescription(schedule) {
 
 //// Global state queries
 
-function courseAlreadyAdded(course) {
+function courseAlreadyAdded(course, selectedCoursesList) {
   return _.some(selectedCourse => {
     return selectedCourse.courseCode === course.courseCode;
-  }, gSelectedCourses);
+  }, selectedCoursesList);
 }
 
 /// API retrieval
@@ -1280,7 +1280,7 @@ function rerenderCourseSearchResults() {
     ++index
   ) {
     const course = gApiData.data.courses[gFilteredCourseKeys[index]];
-    const alreadyAdded = courseAlreadyAdded(course);
+    const alreadyAdded = courseAlreadyAdded(course, gSelectedCourses);
     const entity = createCourseEntity(course, { alreadyAdded });
     entity.style.top = "" + gCourseEntityHeight * index + "px";
     courseSearchResultsList.appendChild(entity);
@@ -1445,7 +1445,7 @@ function handleGlobalStateUpdate() {
 //// Global state mutation
 
 function addCourse(course) {
-  if (courseAlreadyAdded(course)) {
+  if (courseAlreadyAdded(course, gSelectedCourses)) {
     return;
   }
   course = deepCopy(course);
@@ -1464,8 +1464,10 @@ function addToSchedules(course) {
         _.isArray,
         []
       );
-      oldSchedule.push(course);
-      localStorage.setItem(`schedulesSelected${schedule}`, oldSchedule);
+      if (!courseAlreadyAdded(course, oldSchedule)) {
+        oldSchedule.push(course);
+        localStorage.setItem(`schedulesSelected${schedule}`, oldSchedule);
+      }
     }
   }
 }

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1567,11 +1567,19 @@ function toggleCourseStarred(course) {
 
 function toggleScheduleSelected() {
   let schedArr = event.target.parentNode.children;
-  console.log(schedArr);
-  console.log("hi");
   if (schedArr[1].classList.contains("ion-android-checkbox")) {
-    schedArr[1].classList.remove("ion-android-checkbox");
-    schedArr[1].classList.add("ion-android-checkbox-outline-blank");
+    // Check first that at least one other schedule is still checked
+    let numChecked = 0;
+    for (let l of document.getElementsByClassName("schedule-checkbox")) {
+      if (l.checked) numChecked++;
+    }
+    console.log(numChecked);
+    if (numChecked >= 1) {
+      schedArr[1].classList.remove("ion-android-checkbox");
+      schedArr[1].classList.add("ion-android-checkbox-outline-blank");
+    } else {
+      schedArr[0].checked = true;
+    }
   } else {
     schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
     schedArr[1].classList.add("ion-android-checkbox");

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -39,6 +39,8 @@ const schedule2 = document.getElementById("schedule2");
 const schedule3 = document.getElementById("schedule3");
 const schedule4 = document.getElementById("schedule4");
 
+const scheduleLabels = document.getElementsByClassName("schedule-label");
+
 const closedCoursesToggle = document.getElementById("closed-courses-toggle");
 const hideAllConflictingCoursesToggle = document.getElementById(
   "all-conflicting-courses-toggle"
@@ -845,6 +847,11 @@ function attachListeners() {
   schedule2.addEventListener("click", checkSchedule);
   schedule3.addEventListener("click", checkSchedule);
   schedule4.addEventListener("click", checkSchedule);
+
+  for (let label of scheduleLabels) {
+    label.addEventListener("change", toggleScheduleSelected);
+  }
+
   closedCoursesToggle.addEventListener("click", toggleClosedCourses);
   hideAllConflictingCoursesToggle.addEventListener(
     "click",
@@ -1556,6 +1563,19 @@ function toggleCourseStarred(course) {
   course.starred = !course.starred;
   updateCourseDisplays();
   writeStateToLocalStorage();
+}
+
+function toggleScheduleSelected() {
+  let schedArr = event.target.parentNode.children;
+  console.log(schedArr);
+  console.log("hi");
+  if (schedArr[1].classList.contains("ion-android-checkbox")) {
+    schedArr[1].classList.remove("ion-android-checkbox");
+    schedArr[1].classList.add("ion-android-checkbox-outline-blank");
+  } else {
+    schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
+    schedArr[1].classList.add("ion-android-checkbox");
+  }
 }
 
 function updateCourseDisplays() {


### PR DESCRIPTION
Implements the ability for users to keep track of 4 separate schedules and add courses to them individually. For even easier use, users are able to add classes to multiple schedules simultaneously (adding a course adds to all schedules with a check by their name). In the future, we may have the option of renaming schedules (right now they are Schedule1-Schedule4). 

![Screenshot from 2020-04-23 22-13-54](https://user-images.githubusercontent.com/44514622/80177185-c212bb80-85af-11ea-9c97-fa4263bc923a.png)

Also updated help modal to reflect these changes.

![Screenshot from 2020-04-23 22-20-14](https://user-images.githubusercontent.com/44514622/80177462-ad82f300-85b0-11ea-9ddc-b2272586f2d4.png)

![Screenshot from 2020-04-23 22-20-27](https://user-images.githubusercontent.com/44514622/80177469-b1af1080-85b0-11ea-8e83-6d9e700063e2.png)

This is part of CS121 Group 2. Team members include @JeremyTsaii, @godpng, @rory6103.

