### PR TITLE
Add Multiple Schedules (Issue #140)

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -130,17 +130,10 @@ body {
 
 /** Multiple schedules buttons **/
 
-.course-schedule-button-content {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-}
-
 .schedule-checkbox {
   flex-grow: 0;
   flex-basis: 0;
   display: none;
-  justify-self: start;
 }
 
 .schedule-label {
@@ -149,7 +142,7 @@ body {
 }
 
 .schedule-delete-button {
-  margin: 0em 0em 0em 0.75em;
+  margin: 0em 0em 0em .5em;
 }
 
 .schedule-edit-button {
@@ -158,10 +151,24 @@ body {
 
 .schedule-element {
   display: flex;
-  flex-direction: row;
-  justify-content: center;
+  justify-content: space-between;
 }
 
+#schedule-dropdown-add-wrapper {
+  display: flex;
+  justify-content: space-around;
+  cursor: pointer;
+}
+
+#schedule-dropdown-add-text {
+  margin: .33em 1em .25em .5em;
+  padding: 0 0;
+}
+
+#schedule-dropdown-add {
+  margin: .25em .5em .25em 1em;
+  padding: 0 0;
+}
 /** Course search **/
 
 #course-search-column {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -75,11 +75,12 @@ body {
 }
 
 #course-search-schedule-toggle-bar {
-  margin: 1rem 0 1rem 1rem;
+  margin: 1rem 0 0 1rem;
 }
 
 #course-schedules-buttons-bar {
   margin: 1rem 0 1rem 1rem;
+  padding: 0 0;
   justify-content: space-around;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -107,6 +107,8 @@ body {
   flex-basis: 5%;
   flex-grow: 1;
   margin: 0 auto;
+  outline: none;
+  box-shadow: none;
 }
 
 #schedule-dropdown-content {
@@ -152,6 +154,7 @@ body {
 .schedule-element {
   display: flex;
   justify-content: space-between;
+  margin: 0em .25em .25em .25em;
 }
 
 .schedule-delete-placeholder {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -139,6 +139,11 @@ body {
   display: none;
 }
 
+.schedule-label {
+  padding: 0 0;
+  margin: 0em .35em 0em 0em;
+}
+
 .schedule-element {
   display: flex;
   flex-direction: row;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -144,7 +144,11 @@ body {
 
 .schedule-label {
   padding: 0 0;
-  margin: 0em 0.35em 0em 0em;
+  margin: 0em 0.5em 0em 0em;
+}
+
+.schedule-delete-button {
+  margin: 0em 0em 0em .5em;
 }
 
 .schedule-element {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -80,6 +80,7 @@ body {
 
 #course-search-toggle-wrapper,
 #schedule-toggle-wrapper {
+  display: flex;
   flex-grow: 1;
   flex-basis: 0;
 }
@@ -98,6 +99,14 @@ body {
   display: block;
   margin: 0 auto;
   width: 100%;
+  flex-basis: 95%;
+  flex-grow: 1;
+}
+
+#schedule-dropdown-toggle {
+  flex-basis: 5%;
+  flex-grow: 1;
+  margin: 0 auto;
 }
 
 #schedule-column {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -78,10 +78,25 @@ body {
   margin: 1rem 0 1rem 1rem;
 }
 
+#course-schedules-buttons-bar {
+  margin: 1rem 0 1rem 1rem;
+}
+
 #course-search-toggle-wrapper,
 #schedule-toggle-wrapper {
   flex-grow: 1;
   flex-basis: 0;
+}
+
+#schedule-1-wrapper,
+#schedule-2-wrapper,
+#schedule-3-wrapper,
+#schedule-4-wrapper {
+  flex-grow: 1;
+  flex-basis: 0;
+  display: block;
+  margin: 0 auto;
+  width: 100%;
 }
 
 #course-search-toggle {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -58,10 +58,10 @@
   > .dropdown-toggle.change-dropdown-color
   .show
   > .dropdown-toggle.change-dropdown-color {
-  box-shadow: none;
-  outline: none;
-  background-color: #71ff33;
-  border-color: #71ff33;
+  box-shadow: none !important;
+  outline: none !important;
+  background-color: #71ff33 !important;
+  border-color: #71ff33 !important;
 }
 
 .change-tab-color {
@@ -71,14 +71,15 @@
   border: none;
 }
 
+/*this is somehow being overwritten by bootstrap still, so needs !important... to increase priority, make by id instead of classname?*/
 .change-tab-color:hover,
 .change-tab-color:focus,
 .change-tab-color:active,
 .change-tab-color.active,
 .open > .dropdown-toggle.change-tab-color {
-  box-shadow: none;
-  color: black;
-  background-color: #71ff33;
+  box-shadow: none !important;
+  color: black !important;
+  background-color: #71ff33 !important;
 }
 
 /** Page layout **/

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -154,21 +154,30 @@ body {
   justify-content: space-between;
 }
 
+.schedule-delete-placeholder {
+  visibility: hidden;
+}
+
+#schedule-dropdown-content {
+  width: 300px;
+}
+
 #schedule-dropdown-add-wrapper {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   cursor: pointer;
 }
 
 #schedule-dropdown-add-text {
-  margin: .33em 1em .25em .5em;
+  margin: .25em 0 .25em 0;
   padding: 0 0;
 }
 
 #schedule-dropdown-add {
-  margin: .25em .5em .25em 1em;
+  margin: .25em 1em .25em 0;
   padding: 0 0;
 }
+
 /** Course search **/
 
 #course-search-column {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -126,7 +126,7 @@ body {
 }
 
 .schedule-label {
-  margin: 0em .5em;
+  margin: 0em 0.5em;
 }
 
 #course-schedules-buttons-bar {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -45,8 +45,8 @@
 
 .change-dropdown-color {
   box-shadow: none;
-  border-color: #007bff;
-  color: #007bff;
+  border-color: transparent;
+  color: transparent;
   background-color: transparent;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -109,6 +109,11 @@ body {
   margin: 0 auto;
 }
 
+#schedule-dropdown-content {
+  position: absolute;
+  z-index: 1;
+}
+
 #schedule-column {
   overflow-y: auto;
   display: flex;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -139,9 +139,11 @@ body {
   display: none;
 }
 
-.schedule-label {
-  margin: 0em 0.5em;
+.schedule-element {
+  display: flex;
+  flex-direction: row;
 }
+
 
 #course-schedules-buttons-bar {
   margin: 1rem 0 1rem 1rem;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -75,7 +75,7 @@ body {
 }
 
 #course-search-schedule-toggle-bar {
-  margin: 1rem 0 0 1rem;
+  margin: 1rem 0 1rem 1rem;
 }
 
 #course-search-toggle-wrapper,
@@ -147,20 +147,6 @@ body {
 .schedule-element {
   display: flex;
   flex-direction: row;
-}
-
-#course-schedules-buttons-bar {
-  margin: 1rem 0 1rem 1rem;
-  padding: 0 0;
-  justify-content: space-around;
-}
-
-#schedule1,
-#schedule2,
-#schedule3,
-#schedule4 {
-  flex-grow: 1;
-  flex-basis: 0;
 }
 
 /** Course search **/

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -45,25 +45,27 @@
 
 .change-dropdown-color {
   box-shadow: none;
-  border-color: #007bff;
-  color: #007bff;
+  border-color: #71ff33;
+  color: #71ff33;
 }
 
+/*this is somehow being overwritten by bootstrap still, so needs !important... to increase priority, make by id instead of classname?*/
 .change-dropdown-color:hover,
 .change-dropdown-color:focus,
 .change-dropdown-color:active,
 .change-dropdown-color.active,
-.open > .dropdown-toggle.change-dropdown-color {
+.open > .dropdown-toggle.change-dropdown-color
+.show > .dropdown-toggle.change-dropdown-color {
   box-shadow: none;
-  color: #fff;
-  background-color: #007bff;
-  border-color: #007bff;
+  outline: none;
+  background-color: #71ff33;
+  border-color: #71ff33;
 }
 
 .change-tab-color {
   box-shadow: none;
   color: black;
-  background-color: #007bff;
+  background-color: #71ff33;
   border: none;
 }
 
@@ -74,7 +76,7 @@
 .open > .dropdown-toggle.change-tab-color {
   box-shadow: none;
   color: black;
-  background-color: #007bff;
+  background-color: #71ff33;
 }
 
 /** Page layout **/

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -153,7 +153,7 @@ body {
 }
 
 .schedule-edit-button {
-  margin: 0em .5em 0em 0em;
+  margin: 0em 0.5em 0em 0em;
 }
 
 .schedule-element {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -163,6 +163,7 @@ body {
 
 #schedule-dropdown-content {
   width: 300px;
+  z-index: 20;
 }
 
 #schedule-dropdown-add-wrapper {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -141,14 +141,13 @@ body {
 
 .schedule-label {
   padding: 0 0;
-  margin: 0em .35em 0em 0em;
+  margin: 0em 0.35em 0em 0em;
 }
 
 .schedule-element {
   display: flex;
   flex-direction: row;
 }
-
 
 #course-schedules-buttons-bar {
   margin: 1rem 0 1rem 1rem;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -147,6 +147,7 @@ body {
 .schedule-element {
   display: flex;
   flex-direction: row;
+  justify-content: center;
 }
 
 /** Course search **/

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -41,6 +41,42 @@
   whitespace: nowrap;
 }
 
+/** Alter colors when switching schedules **/
+
+.change-dropdown-color {
+  box-shadow: none;
+  border-color: #007bff;
+  color: #007bff;
+}
+
+.change-dropdown-color:hover,
+.change-dropdown-color:focus,
+.change-dropdown-color:active,
+.change-dropdown-color.active,
+.open > .dropdown-toggle.change-dropdown-color {
+  box-shadow: none;
+  color: #fff;
+  background-color: #007bff;
+  border-color: #007bff;
+}
+
+.change-tab-color {
+  box-shadow: none;
+  color: black;
+  background-color: #007bff;
+  border: none;
+}
+
+.change-tab-color:hover,
+.change-tab-color:focus,
+.change-tab-color:active,
+.change-tab-color.active,
+.open > .dropdown-toggle.change-tab-color {
+  box-shadow: none;
+  color: black;
+  background-color: #007bff;
+}
+
 /** Page layout **/
 
 html {
@@ -144,7 +180,7 @@ body {
 }
 
 .schedule-delete-button {
-  margin: 0em 0em 0em .5em;
+  margin: 0em 0em 0em 0.5em;
 }
 
 .schedule-edit-button {
@@ -154,7 +190,7 @@ body {
 .schedule-element {
   display: flex;
   justify-content: space-between;
-  margin: 0em .25em .25em .25em;
+  margin: 0em 0.25em 0.25em 0.25em;
 }
 
 .schedule-delete-placeholder {
@@ -173,12 +209,12 @@ body {
 }
 
 #schedule-dropdown-add-text {
-  margin: .25em 0 .25em 0;
+  margin: 0.25em 0 0.25em 0;
   padding: 0 0;
 }
 
 #schedule-dropdown-add {
-  margin: .25em 1em .25em 0;
+  margin: 0.25em 1em 0.25em 0;
   padding: 0 0;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -54,8 +54,10 @@
 .change-dropdown-color:focus,
 .change-dropdown-color:active,
 .change-dropdown-color.active,
-.open > .dropdown-toggle.change-dropdown-color
-.show > .dropdown-toggle.change-dropdown-color {
+.open
+  > .dropdown-toggle.change-dropdown-color
+  .show
+  > .dropdown-toggle.change-dropdown-color {
   box-shadow: none;
   outline: none;
   background-color: #71ff33;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -148,7 +148,7 @@ body {
 }
 
 .schedule-delete-button {
-  margin: 0em 0em 0em .5em;
+  margin: 0em 0em 0em 0.5em;
 }
 
 .schedule-element {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -78,22 +78,8 @@ body {
   margin: 1rem 0 0 1rem;
 }
 
-#course-schedules-buttons-bar {
-  margin: 1rem 0 1rem 1rem;
-  padding: 0 0;
-  justify-content: space-around;
-}
-
 #course-search-toggle-wrapper,
 #schedule-toggle-wrapper {
-  flex-grow: 1;
-  flex-basis: 0;
-}
-
-#schedule1,
-#schedule2,
-#schedule3,
-#schedule4 {
   flex-grow: 1;
   flex-basis: 0;
 }
@@ -123,6 +109,38 @@ body {
 
 #schedule-column.hidden {
   display: none;
+}
+
+/** Multiple schedules buttons **/
+
+.course-schedule-button-content {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+.schedule-checkbox {
+  flex-grow: 0;
+  flex-basis: 0;
+  display: none;
+}
+
+.schedule-label {
+  margin: 0em .5em;
+}
+
+#course-schedules-buttons-bar {
+  margin: 1rem 0 1rem 1rem;
+  padding: 0 0;
+  justify-content: space-around;
+}
+
+#schedule1,
+#schedule2,
+#schedule3,
+#schedule4 {
+  flex-grow: 1;
+  flex-basis: 0;
 }
 
 /** Course search **/

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -112,6 +112,9 @@ body {
 #schedule-dropdown-content {
   position: absolute;
   z-index: 1;
+  height: auto;
+  max-height: 30em;
+  overflow-x: hidden;
 }
 
 #schedule-column {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -151,6 +151,10 @@ body {
   margin: 0em 0em 0em 0.5em;
 }
 
+.schedule-edit-button {
+  margin: 0em .5em 0em 0em;
+}
+
 .schedule-element {
   display: flex;
   flex-direction: row;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -80,6 +80,7 @@ body {
 
 #course-schedules-buttons-bar {
   margin: 1rem 0 1rem 1rem;
+  justify-content: space-around;
 }
 
 #course-search-toggle-wrapper,
@@ -88,15 +89,12 @@ body {
   flex-basis: 0;
 }
 
-#schedule-1-wrapper,
-#schedule-2-wrapper,
-#schedule-3-wrapper,
-#schedule-4-wrapper {
+#schedule1,
+#schedule2,
+#schedule3,
+#schedule4 {
   flex-grow: 1;
   flex-basis: 0;
-  display: block;
-  margin: 0 auto;
-  width: 100%;
 }
 
 #course-search-toggle {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -45,11 +45,11 @@
 
 .change-dropdown-color {
   box-shadow: none;
-  border-color: #71ff33;
-  color: #71ff33;
+  border-color: #007bff;
+  color: #007bff;
+  background-color: transparent;
 }
 
-/*this is somehow being overwritten by bootstrap still, so needs !important... to increase priority, make by id instead of classname?*/
 .change-dropdown-color:hover,
 .change-dropdown-color:focus,
 .change-dropdown-color:active,
@@ -60,18 +60,18 @@
   > .dropdown-toggle.change-dropdown-color {
   box-shadow: none !important;
   outline: none !important;
-  background-color: #71ff33 !important;
-  border-color: #71ff33 !important;
+  background-color: #007bff !important;
+  border-color: #007bff !important;
+  color: white !important;
 }
 
 .change-tab-color {
   box-shadow: none;
   color: black;
-  background-color: #71ff33;
+  background-color: #007bff;
   border: none;
 }
 
-/*this is somehow being overwritten by bootstrap still, so needs !important... to increase priority, make by id instead of classname?*/
 .change-tab-color:hover,
 .change-tab-color:focus,
 .change-tab-color:active,
@@ -79,7 +79,7 @@
 .open > .dropdown-toggle.change-tab-color {
   box-shadow: none !important;
   color: black !important;
-  background-color: #71ff33 !important;
+  background-color: #007bff !important;
 }
 
 /** Page layout **/

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -140,6 +140,7 @@ body {
   flex-grow: 0;
   flex-basis: 0;
   display: none;
+  justify-self: start;
 }
 
 .schedule-label {
@@ -148,7 +149,7 @@ body {
 }
 
 .schedule-delete-button {
-  margin: 0em 0em 0em 0.5em;
+  margin: 0em 0em 0em 0.75em;
 }
 
 .schedule-edit-button {

--- a/src/index.html
+++ b/src/index.html
@@ -63,32 +63,40 @@
       <div id="course-schedules-buttons-bar" class="toolbar">
         <div class="course-schedule-button-content btn" id="schedule1">
           <label id="schedule1-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
+            <input type="checkbox" class="schedule-checkbox" />
+            <i
+              class="schedule-icon icon ion-android-checkbox-outline-blank"
+            ></i>
           </label>
           Schedule1
         </div>
         <div class="course-schedule-button-content btn" id="schedule2">
           <label id="schedule2-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
+            <input type="checkbox" class="schedule-checkbox" />
+            <i
+              class="schedule-icon icon ion-android-checkbox-outline-blank"
+            ></i>
           </label>
           Schedule2
         </div>
         <div class="course-schedule-button-content btn" id="schedule3">
           <label id="schedule3-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
+            <input type="checkbox" class="schedule-checkbox" />
+            <i
+              class="schedule-icon icon ion-android-checkbox-outline-blank"
+            ></i>
           </label>
           Schedule3
         </div>
         <div class="course-schedule-button-content btn" id="schedule4">
           <label id="schedule4-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
+            <input type="checkbox" class="schedule-checkbox" />
+            <i
+              class="schedule-icon icon ion-android-checkbox-outline-blank"
+            ></i>
           </label>
           Schedule4
-        </div>       
+        </div>
       </div>
       <div id="course-search-column">
         <div id="course-search-bar" class="toolbar">

--- a/src/index.html
+++ b/src/index.html
@@ -61,17 +61,34 @@
         </div>
       </div>
       <div id="course-schedules-buttons-bar" class="toolbar">
-          <button type="button" id="schedule1" class="btn">
-            schedule1
-          </button>
-          <button type="button" id="schedule2" class="btn">
-            schedule2
-          </button>
-          <button type="button" id="schedule3" class="btn">
-            schedule3
-          </button>
-          <button type="button" id="schedule4" class="btn">
-            schedule4
+        <div class="course-schedule-button-content btn" id="schedule1">
+          <label id="schedule1-checkbox" class="schedule-label">
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox"></i>
+          </label>
+          Schedule1
+        </div>
+        <div class="course-schedule-button-content btn" id="schedule2">
+          <label id="schedule2-checkbox" class="schedule-label">
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox"></i>
+          </label>
+          Schedule2
+        </div>
+        <div class="course-schedule-button-content btn" id="schedule3">
+          <label id="schedule3-checkbox" class="schedule-label">
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox"></i>
+          </label>
+          Schedule3
+        </div>
+        <div class="course-schedule-button-content btn" id="schedule4">
+          <label id="schedule4-checkbox" class="schedule-label">
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox"></i>
+          </label>
+          Schedule4
+        </div>       
       </div>
       <div id="course-search-column">
         <div id="course-search-bar" class="toolbar">

--- a/src/index.html
+++ b/src/index.html
@@ -69,6 +69,7 @@
               id="schedule-dropdown-content"
               class="dropdown-menu dropdown-menu-right"
             >
+              <span id="schedule-dropdown-content-text">Your Courses: </span>
               <button
                 type="button"
                 id="schedule-dropdown-add"

--- a/src/index.html
+++ b/src/index.html
@@ -486,7 +486,8 @@
               </li>
             </ul>
             <p>
-              Click on the <b>+</b> button to add a course. Each section is
+              Click on the <b>+</b> button to add a course. The course will be
+              added to all schedules with a check next to them. Each section is
               listed separately, so make sure to get all the ones you want. You
               can click on a course to see more information about it in the
               upper-right panel.
@@ -505,7 +506,10 @@
               algorithm starts from the top of your list and goes down. Courses
               that are disabled, however, won't be considered. So, to change
               your schedule, just use reordering, starring, and disabling,
-              rather than paging through multiple schedules.
+              rather than paging through multiple schedules. View your different
+              schedules on the calendar interface one at at time by clicking on
+              the schedule tabs below the <b>Course Search</b> and
+              <b>Schedule</b> tabs.
             </p>
             <p>
               Hyperschedule was created by Radon Rosborough

--- a/src/index.html
+++ b/src/index.html
@@ -69,7 +69,7 @@
               id="schedule-dropdown-content"
               class="dropdown-menu dropdown-menu-right"
             >
-              <span id="schedule-dropdown-content-text">Your Courses: </span>
+              <span id="schedule-dropdown-content-text"></span>
               <button
                 type="button"
                 id="schedule-dropdown-add"

--- a/src/index.html
+++ b/src/index.html
@@ -58,6 +58,8 @@
           <button type="button" id="schedule-toggle" class="btn">
             Schedule
           </button>
+          <button type="button" id="schedule-dropdown-toggle" class="btn btn-outline-primary dropdown-toggle">
+          </button>
         </div>
       </div>
       <div id="course-schedules-buttons-bar" class="toolbar">

--- a/src/index.html
+++ b/src/index.html
@@ -74,47 +74,9 @@
                 type="button"
                 id="schedule-dropdown-add"
                 class="btn icon ion-plus"
-              ></button>
+              >Add Schedule</button>
             </div>
           </div>
-        </div>
-      </div>
-      <div id="course-schedules-buttons-bar" class="toolbar">
-        <div class="course-schedule-button-content btn" id="schedule1">
-          <label id="schedule1-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox" />
-            <i
-              class="schedule-icon icon ion-android-checkbox-outline-blank"
-            ></i>
-          </label>
-          Schedule1
-        </div>
-        <div class="course-schedule-button-content btn" id="schedule2">
-          <label id="schedule2-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox" />
-            <i
-              class="schedule-icon icon ion-android-checkbox-outline-blank"
-            ></i>
-          </label>
-          Schedule2
-        </div>
-        <div class="course-schedule-button-content btn" id="schedule3">
-          <label id="schedule3-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox" />
-            <i
-              class="schedule-icon icon ion-android-checkbox-outline-blank"
-            ></i>
-          </label>
-          Schedule3
-        </div>
-        <div class="course-schedule-button-content btn" id="schedule4">
-          <label id="schedule4-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox" />
-            <i
-              class="schedule-icon icon ion-android-checkbox-outline-blank"
-            ></i>
-          </label>
-          Schedule4
         </div>
       </div>
       <div id="course-search-column">

--- a/src/index.html
+++ b/src/index.html
@@ -60,6 +60,28 @@
           </button>
         </div>
       </div>
+      <div id="course-schedules-buttons-bar" class="toolbar">
+        <div id="schedule-1-wrapper">
+          <button type="button" id="schedule1" class="btn">
+            schedule1
+          </button>
+        </div>
+        <div id="schedule-2-wrapper">
+          <button type="button" id="schedule2" class="btn">
+            schedule2
+          </button>
+        </div>
+        <div id="schedule-3-wrapper">
+          <button type="button" id="schedule3" class="btn">
+            schedule3
+          </button>
+        </div>
+        <div id="schedule-4-wrapper">
+          <button type="button" id="schedule4" class="btn">
+            schedule4
+          </button>
+        </div>
+      </div>
       <div id="course-search-column">
         <div id="course-search-bar" class="toolbar">
           <input

--- a/src/index.html
+++ b/src/index.html
@@ -63,7 +63,7 @@
       <div id="course-schedules-buttons-bar" class="toolbar">
         <div class="course-schedule-button-content btn" id="schedule1">
           <label id="schedule1-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox"/>
+            <input type="checkbox" class="schedule-checkbox" checked="true"/>
             <i class="schedule-icon icon ion-android-checkbox"></i>
           </label>
           Schedule1
@@ -71,21 +71,21 @@
         <div class="course-schedule-button-content btn" id="schedule2">
           <label id="schedule2-checkbox" class="schedule-label">
             <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox"></i>
+            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
           </label>
           Schedule2
         </div>
         <div class="course-schedule-button-content btn" id="schedule3">
           <label id="schedule3-checkbox" class="schedule-label">
             <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox"></i>
+            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
           </label>
           Schedule3
         </div>
         <div class="course-schedule-button-content btn" id="schedule4">
           <label id="schedule4-checkbox" class="schedule-label">
             <input type="checkbox" class="schedule-checkbox"/>
-            <i class="schedule-icon icon ion-android-checkbox"></i>
+            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
           </label>
           Schedule4
         </div>       

--- a/src/index.html
+++ b/src/index.html
@@ -469,10 +469,11 @@
             </ul>
             <p>
               Click on the <b>+</b> button to add a course. The course will be
-              added to all schedules with a check next to them. Each section is
-              listed separately, so make sure to get all the ones you want. You
-              can click on a course to see more information about it in the
-              upper-right panel.
+              added to all schedules with a check next to them, viewable by
+              clicking on the arrow drop down to the right of the
+              <b>Schedule</b> tab. Each course section is listed separately, so
+              make sure to get all the ones you want. You can click on a course
+              to see more information about it in the upper-right panel.
             </p>
             <p>
               On the right-hand column, you can click and drag courses to
@@ -488,10 +489,21 @@
               algorithm starts from the top of your list and goes down. Courses
               that are disabled, however, won't be considered. So, to change
               your schedule, just use reordering, starring, and disabling,
-              rather than paging through multiple schedules. View your different
-              schedules on the calendar interface one at at time by clicking on
-              the schedule tabs below the <b>Course Search</b> and
-              <b>Schedule</b> tabs.
+              rather than paging through multiple schedules.
+            </p>
+            <p>
+              To the right of the <b>Schedule</b> tab, you can click on the
+              arrow drop down to create and alternate between
+              <b>multiple schedules</b>. Click on the
+              <b>+ Add Schedule</b> button and enter a schedule name to create a
+              new schedule. You can always edit schedule names by clicking the
+              pencil icon and delete schedules by clicking the X icon. View your
+              different schedules on the calendar interface one at at time by
+              clicking on the specific schedule in the drop down menu, putting
+              it in focus. You can even add courses to multiple schedules
+              simultaneously. Simply check the box at the left of a schedule row
+              and any courses added to the current, focused schedule will also
+              be added to this schedule.
             </p>
             <p>
               Hyperschedule was created by Radon Rosborough

--- a/src/index.html
+++ b/src/index.html
@@ -62,7 +62,7 @@
             <button
               type="button"
               id="schedule-dropdown-toggle-btn"
-              class="btn btn-outline-primary dropdown-toggle change-dropdown-color"
+              class="btn dropdown-toggle change-dropdown-color"
               data-toggle="dropdown"
             ></button>
             <div

--- a/src/index.html
+++ b/src/index.html
@@ -64,15 +64,6 @@
             <div id="schedule-dropdown-content" class="dropdown-menu dropdown-menu-right">
               <button type="button" id="schedule-dropdown-add" class="btn icon ion-plus">
               </button>
-              <div id="schedule-1" class="schedule-element btn">
-                <label id="schedule-1-checkbox" class="schedule-label">
-                  <input type="checkbox" class="schedule-checkbox" />
-                  <i
-                    class="schedule-icon icon ion-android-checkbox-outline-blank"
-                  ></i>
-                </label>
-                Schedule1
-              </div>
             </div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -59,11 +59,21 @@
             Schedule
           </button>
           <div id="schedule-dropdown-toggle" class="dropdown">
-            <button type="button" id="schedule-dropdown-toggle" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown">
-            </button>
-            <div id="schedule-dropdown-content" class="dropdown-menu dropdown-menu-right">
-              <button type="button" id="schedule-dropdown-add" class="btn icon ion-plus">
-              </button>
+            <button
+              type="button"
+              id="schedule-dropdown-toggle"
+              class="btn btn-outline-primary dropdown-toggle"
+              data-toggle="dropdown"
+            ></button>
+            <div
+              id="schedule-dropdown-content"
+              class="dropdown-menu dropdown-menu-right"
+            >
+              <button
+                type="button"
+                id="schedule-dropdown-add"
+                class="btn icon ion-plus"
+              ></button>
             </div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -74,7 +74,9 @@
                 type="button"
                 id="schedule-dropdown-add"
                 class="btn icon ion-plus"
-              >Add Schedule</button>
+              >
+                Add Schedule
+              </button>
             </div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -69,7 +69,6 @@
               id="schedule-dropdown-content"
               class="dropdown-menu dropdown-menu-right"
             >
-              <span id="schedule-dropdown-content-text"></span>
               <button
                 type="button"
                 id="schedule-dropdown-add"

--- a/src/index.html
+++ b/src/index.html
@@ -63,8 +63,8 @@
       <div id="course-schedules-buttons-bar" class="toolbar">
         <div class="course-schedule-button-content btn" id="schedule1">
           <label id="schedule1-checkbox" class="schedule-label">
-            <input type="checkbox" class="schedule-checkbox" checked="true"/>
-            <i class="schedule-icon icon ion-android-checkbox"></i>
+            <input type="checkbox" class="schedule-checkbox"/>
+            <i class="schedule-icon icon ion-android-checkbox-outline-blank"></i>
           </label>
           Schedule1
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -69,13 +69,15 @@
               id="schedule-dropdown-content"
               class="dropdown-menu dropdown-menu-right"
             >
-              <button
-                type="button"
-                id="schedule-dropdown-add"
-                class="btn icon ion-plus"
-              >
-                Add Schedule
-              </button>
+              <div id="schedule-dropdown-add-wrapper">
+                <button
+                  type="button"
+                  id="schedule-dropdown-add"
+                  class="btn icon ion-plus"
+                >
+                </button>
+                <span id="schedule-dropdown-add-text">Add Schedule</span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -65,6 +65,12 @@
               <button type="button" id="schedule-dropdown-add" class="btn icon ion-plus">
               </button>
               <div id="schedule-1" class="schedule-element btn">
+                <label id="schedule-1-checkbox" class="schedule-label">
+                  <input type="checkbox" class="schedule-checkbox" />
+                  <i
+                    class="schedule-icon icon ion-android-checkbox-outline-blank"
+                  ></i>
+                </label>
                 Schedule1
               </div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -61,8 +61,8 @@
           <div id="schedule-dropdown-toggle" class="dropdown">
             <button
               type="button"
-              id="schedule-dropdown-toggle"
-              class="btn btn-outline-primary dropdown-toggle"
+              id="schedule-dropdown-toggle-btn"
+              class="btn btn-outline-primary dropdown-toggle change-dropdown-color"
               data-toggle="dropdown"
             ></button>
             <div
@@ -70,11 +70,7 @@
               class="dropdown-menu dropdown-menu-right"
             >
               <div id="schedule-dropdown-add-wrapper">
-                <i
-                  id="schedule-dropdown-add"
-                  class="icon ion-plus"
-                >
-              </i>
+                <i id="schedule-dropdown-add" class="icon ion-plus"> </i>
                 <span id="schedule-dropdown-add-text">Add Schedule</span>
               </div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -61,26 +61,17 @@
         </div>
       </div>
       <div id="course-schedules-buttons-bar" class="toolbar">
-        <div id="schedule-1-wrapper">
           <button type="button" id="schedule1" class="btn">
             schedule1
           </button>
-        </div>
-        <div id="schedule-2-wrapper">
           <button type="button" id="schedule2" class="btn">
             schedule2
           </button>
-        </div>
-        <div id="schedule-3-wrapper">
           <button type="button" id="schedule3" class="btn">
             schedule3
           </button>
-        </div>
-        <div id="schedule-4-wrapper">
           <button type="button" id="schedule4" class="btn">
             schedule4
-          </button>
-        </div>
       </div>
       <div id="course-search-column">
         <div id="course-search-bar" class="toolbar">

--- a/src/index.html
+++ b/src/index.html
@@ -58,8 +58,17 @@
           <button type="button" id="schedule-toggle" class="btn">
             Schedule
           </button>
-          <button type="button" id="schedule-dropdown-toggle" class="btn btn-outline-primary dropdown-toggle">
-          </button>
+          <div id="schedule-dropdown-toggle" class="dropdown">
+            <button type="button" id="schedule-dropdown-toggle" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown">
+            </button>
+            <div id="schedule-dropdown-content" class="dropdown-menu dropdown-menu-right">
+              <button type="button" id="schedule-dropdown-add" class="btn icon ion-plus">
+              </button>
+              <div id="schedule-1" class="schedule-element btn">
+                Schedule1
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <div id="course-schedules-buttons-bar" class="toolbar">

--- a/src/index.html
+++ b/src/index.html
@@ -70,12 +70,11 @@
               class="dropdown-menu dropdown-menu-right"
             >
               <div id="schedule-dropdown-add-wrapper">
-                <button
-                  type="button"
+                <i
                   id="schedule-dropdown-add"
-                  class="btn icon ion-plus"
+                  class="icon ion-plus"
                 >
-                </button>
+              </i>
                 <span id="schedule-dropdown-add-text">Add Schedule</span>
               </div>
             </div>

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1491,14 +1491,16 @@ function addToSchedules(course) {
   for (const schedule of gSchedulesSelected) {
     if (schedule !== gLastScheduleSelected) {
       let oldSchedule = readFromLocalStorage(
-        `schedulesSelected${schedule}`,
+        `selectedCourses${schedule}`,
         _.isArray,
         []
       );
-      console.log(oldSchedule);
       if (!courseAlreadyAdded(course, oldSchedule)) {
         oldSchedule.push(course);
-        localStorage.setItem(`schedulesSelected${schedule}`, oldSchedule);
+        localStorage.setItem(
+          `selectedCourses${schedule}`,
+          JSON.stringify(oldSchedule)
+        );
       }
     }
   }
@@ -1626,6 +1628,18 @@ function checkSchedule() {
     event.target.className === "course-schedule-button-content btn btn-light" ||
     event.target.className === "course-schedule-button-content btn btn-info"
   ) {
+    // Uncheck previously selected schedule
+    if (gSchedulesSelected.includes(gLastScheduleSelected)) {
+      gSchedulesSelected.splice(
+        gSchedulesSelected.indexOf(gLastScheduleSelected),
+        1
+      );
+      const checkBox = document.getElementsByClassName(
+        "schedule-icon icon ion-android-checkbox"
+      )[0];
+      checkBox.classList.remove("ion-android-checkbox");
+      checkBox.classList.add("ion-android-checkbox-outline-blank");
+    }
     gLastScheduleSelected = Number(event.target.id.charAt(8));
     gSelectedCourses = upgradeSelectedCourses(
       readFromLocalStorage(
@@ -1634,6 +1648,14 @@ function checkSchedule() {
         []
       )
     );
+    // Check if not already checked
+    console.log(event.target.children[0].children[1]);
+    if (!gSchedulesSelected.includes(gLastScheduleSelected)) {
+      gSchedulesSelected.push(gLastScheduleSelected);
+      const checkBox = event.target.children[0].children[1];
+      checkBox.classList.remove("ion-android-checkbox-outline-blank");
+      checkBox.classList.add("ion-android-checkbox");
+    }
 
     updateCourseDisplays();
     setScheduleSelected();

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1210,6 +1210,14 @@ function getSearchTextFilters(filtersTextArray) {
 //// DOM updates
 ///// DOM updates due to global state change
 
+function updateScheduleSelectedStartup() {
+  let schedule = document.getElementById("schedule" + gLastScheduleSelected);
+  let schedArr = schedule.children[0].children;
+  schedArr[0].checked = true;
+  schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
+  schedArr[1].classList.add("ion-android-checkbox");
+}
+
 function updateTabToggle() {
   setEntityVisibility(scheduleColumn, gScheduleTabSelected);
   setButtonSelected(scheduleToggle, gScheduleTabSelected);
@@ -1573,7 +1581,6 @@ function toggleScheduleSelected() {
     for (let l of document.getElementsByClassName("schedule-checkbox")) {
       if (l.checked) numChecked++;
     }
-    console.log(numChecked);
     if (numChecked >= 1) {
       schedArr[1].classList.remove("ion-android-checkbox");
       schedArr[1].classList.add("ion-android-checkbox-outline-blank");
@@ -2199,6 +2206,7 @@ readStateFromLocalStorage();
 handleGlobalStateUpdate();
 setScheduleSelected();
 retrieveCourseDataUntilSuccessful();
+updateScheduleSelectedStartup();
 
 /// Closing remarks
 

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -38,11 +38,6 @@ const scheduleDropDownContent = document.getElementById(
 );
 const scheduleDropdownAdd = document.getElementById("schedule-dropdown-add");
 
-const schedule1 = document.getElementById("schedule1");
-const schedule2 = document.getElementById("schedule2");
-const schedule3 = document.getElementById("schedule3");
-const schedule4 = document.getElementById("schedule4");
-
 const scheduleLabels = document.getElementsByClassName("schedule-label");
 const scheduleElements = document.getElementsByClassName("schedule-element");
 
@@ -852,10 +847,6 @@ function attachListeners() {
   courseSearchToggle.addEventListener("click", displayCourseSearchColumn);
   scheduleToggle.addEventListener("click", displayScheduleColumn);
   scheduleDropdownAdd.addEventListener("click", addNewSchedule);
-  schedule1.addEventListener("click", checkSchedule);
-  schedule2.addEventListener("click", checkSchedule);
-  schedule3.addEventListener("click", checkSchedule);
-  schedule4.addEventListener("click", checkSchedule);
 
   for (const sched of scheduleElements) {
     sched.addEventListener("click", selectSchedule);

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1574,9 +1574,9 @@ function addNewSchedule() {
     id: newId,
     color: getRandomColor(
       "random",
-      CryptoJS.MD5(newId + inputName).toString(),
+      CryptoJS.MD5(inputName + newId).toString(),
       "hex",
-      "dark"
+      "light"
     )
   };
   gScheduleList.push(defaultPair);

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1223,6 +1223,7 @@ function getSearchTextFilters(filtersTextArray) {
 ///// DOM updates due to global state change
 
 function updateScheduleMenu() {
+  console.log(gScheduleList);
   for (const sched of gScheduleList) {
     appendScheduleRow(sched);
   }
@@ -1487,7 +1488,6 @@ function handleGlobalStateUpdate() {
 
   // Update course displays.
   updateCourseDisplays();
-
   // Canonicalize the state of local storage.
   writeStateToLocalStorage();
 }
@@ -1679,6 +1679,12 @@ function selectSchedule() {
   // intended to replace the old function "setScheduleSelected"
   const schedActive = "btn-info";
   const schedInactive = "btn-light";
+
+  // Update global var and state
+  const scheduleId = event.target.id.charAt(9);
+  gLastScheduleSelected = Number(scheduleId);
+  writeStateToLocalStorage();
+
   if (!event.target.classList.contains(schedActive)) {
     // if schedule isn't already active
 
@@ -1873,6 +1879,7 @@ function writeStateToLocalStorage() {
   localStorage.setItem("apiData", JSON.stringify(gApiData));
   localStorage.setItem("scheduleList", JSON.stringify(gScheduleList));
   localStorage.setItem("lastScheduleSelected", gLastScheduleSelected);
+  localStorage.setItem("lastScheduleId", gLastScheduleId);
   localStorage.setItem("schedulesChecked", [gLastScheduleSelected]);
   localStorage.setItem(
     `selectedCourses${gLastScheduleSelected}`,
@@ -1965,6 +1972,7 @@ function readStateFromLocalStorage() {
     _.isNumber,
     1
   );
+  gLastScheduleId = readFromLocalStorage("lastScheduleId", _.isNumber, 1);
   gSchedulesChecked = readFromLocalStorage("schedulesChecked", _.isArray, [
     gLastScheduleSelected
   ]);
@@ -2335,7 +2343,6 @@ retrieveCourseDataUntilSuccessful();
 updateScheduleSelectedStartup();
 
 /// Closing remarks
-
 // Local Variables:
 // outline-regexp: "///+"
 // End:

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -34,6 +34,11 @@ filterInequalities = ["<=", ">=", "<", ">", "="];
 const courseSearchToggle = document.getElementById("course-search-toggle");
 const scheduleToggle = document.getElementById("schedule-toggle");
 
+const schedule1 = document.getElementById("schedule1");
+const schedule2 = document.getElementById("schedule2");
+const schedule3 = document.getElementById("schedule3");
+const schedule4 = document.getElementById("schedule4");
+
 const closedCoursesToggle = document.getElementById("closed-courses-toggle");
 const hideAllConflictingCoursesToggle = document.getElementById(
   "all-conflicting-courses-toggle"
@@ -110,6 +115,8 @@ const importExportCopyButton = document.getElementById(
 let gApiData = null;
 let gSelectedCourses = [];
 let gScheduleTabSelected = false;
+let gLastScheduleSelected = 1;
+let gSchedulesSelected = [0];
 let gShowClosedCourses = true;
 let gHideAllConflictingCourses = false;
 let gHideStarredConflictingCourses = false;
@@ -818,6 +825,10 @@ function attachListeners() {
 
   courseSearchToggle.addEventListener("click", displayCourseSearchColumn);
   scheduleToggle.addEventListener("click", displayScheduleColumn);
+  schedule1.addEventListener("click", checkSchedule1);
+  schedule2.addEventListener("click", checkSchedule2);
+  schedule3.addEventListener("click", checkSchedule3);
+  schedule4.addEventListener("click", checkSchedule4);
   closedCoursesToggle.addEventListener("click", toggleClosedCourses);
   hideAllConflictingCoursesToggle.addEventListener(
     "click",
@@ -1532,6 +1543,22 @@ function displayScheduleColumn() {
   gScheduleTabSelected = true;
   updateTabToggle();
   writeStateToLocalStorage();
+}
+
+function checkSchedule1() {
+  console.log("schedule 1 clicked");
+}
+
+function checkSchedule2() {
+  console.log("schedule 2 clicked");
+}
+
+function checkSchedule3() {
+  console.log("schedule 3 clicked");
+}
+
+function checkSchedule4() {
+  console.log("schedule 4 clicked");
 }
 
 //// Course retrieval

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -36,7 +36,9 @@ const scheduleToggle = document.getElementById("schedule-toggle");
 const scheduleDropDownContent = document.getElementById(
   "schedule-dropdown-content"
 );
-const scheduleDropdownAdd = document.getElementById("schedule-dropdown-add");
+const scheduleDropdownAdd = document.getElementById(
+  "schedule-dropdown-add-wrapper"
+);
 
 const scheduleLabels = document.getElementsByClassName("schedule-label");
 const scheduleElements = document.getElementsByClassName("schedule-element");

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -550,16 +550,16 @@ function shadeColor(color, percent) {
   G = G < 255 ? G : 255;
   B = B < 255 ? B : 255;
 
-  let RR = R.toString(16).length == 1 ? "0" + R.toString(16) : R.toString(16);
-  let GG = G.toString(16).length == 1 ? "0" + G.toString(16) : G.toString(16);
-  let BB = B.toString(16).length == 1 ? "0" + B.toString(16) : B.toString(16);
+  let RR = R.toString(16).length === 1 ? "0" + R.toString(16) : R.toString(16);
+  let GG = G.toString(16).length === 1 ? "0" + G.toString(16) : G.toString(16);
+  let BB = B.toString(16).length === 1 ? "0" + B.toString(16) : B.toString(16);
 
   return "#" + RR + GG + BB;
 }
 
 // https://stackoverflow.com/questions/13712697/set-background-color-in-hex
 function rgbToHex(col) {
-  if (col.charAt(0) == "r") {
+  if (col.charAt(0) === "r") {
     col = col
       .replace("rgb(", "")
       .replace(")", "")
@@ -567,9 +567,9 @@ function rgbToHex(col) {
     let r = parseInt(col[0], 10).toString(16);
     let g = parseInt(col[1], 10).toString(16);
     let b = parseInt(col[2], 10).toString(16);
-    r = r.length == 1 ? "0" + r : r;
-    g = g.length == 1 ? "0" + g : g;
-    b = b.length == 1 ? "0" + b : b;
+    r = r.length === 1 ? "0" + r : r;
+    g = g.length === 1 ? "0" + g : g;
+    b = b.length === 1 ? "0" + b : b;
     let colHex = "#" + r + g + b;
     return colHex;
   }
@@ -1757,6 +1757,9 @@ function editName() {
       sched.name = inputName;
     }
   }
+  if (gLastScheduleSelected.id === id) {
+    gLastScheduleSelected.name = inputName;
+  }
   // change UI
   const oldName = event.target.parentNode.parentNode.childNodes[1];
   oldName.nodeValue = inputName;
@@ -1876,7 +1879,8 @@ function selectSchedule() {
       "schedule-element btn btn-primary schedule-active" ||
     event.target.className ===
       "schedule-element btn btn-primary schedule-inactive" ||
-    event.target.className === "schedule-element btn"
+    event.target.className === "schedule-element btn" ||
+    event.target.className === "schedule-element btn btn-primary"
   ) {
     // Switch current schedule
     const newName = event.target.textContent;
@@ -1885,6 +1889,7 @@ function selectSchedule() {
 
     // default clicked
     if (newColor === "") {
+      console.log("test");
       gLastScheduleSelected = { name: newName, id: newId, color: "#007bff" };
     } else {
       newColor = rgbToHex(newColor);

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1590,7 +1590,15 @@ function appendScheduleRow(schedule) {
   newSched.id = scheduleId;
   newSched.appendChild(checkEditWrapper);
   newSched.appendChild(newName);
+
+  // Add placeholder for delete so that schedule 1 lines up properly.
+  let fakeDelete = document.createElement("div");
+  fakeDelete.classList.add("schedule-delete-placeholder");
+  fakeDelete.classList.add("icon");
+  fakeDelete.classList.add("ion-close");
+
   if (scheduleId !== "schedule-1") newSched.appendChild(deleteButton);
+  else newSched.appendChild(fakeDelete);
   newSched.addEventListener("click", selectSchedule);
   newSched.addEventListener("click", catchEvent);
   scheduleDropDownContent.appendChild(newSched);

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1599,6 +1599,7 @@ function appendScheduleRow(schedule) {
 
   if (scheduleId !== "schedule-1") newSched.appendChild(deleteButton);
   else newSched.appendChild(fakeDelete);
+
   newSched.addEventListener("click", selectSchedule);
   newSched.addEventListener("click", catchEvent);
 
@@ -1683,7 +1684,6 @@ function editName() {
   }
   // change global var
   for (const sched of gScheduleList) {
-    console.log(sched.name);
     if (sched.id === id) {
       sched.name = inputName;
     }
@@ -1691,6 +1691,9 @@ function editName() {
   // change UI
   const oldName = event.target.parentNode.parentNode.childNodes[1];
   oldName.nodeValue = inputName;
+
+  // update schedule tab to reflect name change
+  updateScheduleTabTitle();
 
   catchEvent(event);
 
@@ -1829,13 +1832,12 @@ function highlightSchedule(event) {
   // multischedules- highlights one schedule in the dropdown
   const schedActive = "schedule-active";
   const schedInactive = "schedule-inactive";
-  console.log("LITT");
   if (
     !event.target.classList.contains(schedActive) &&
     !event.target.classList.contains("schedule-checkbox")
   ) {
     // if schedule isn't already active
-    console.log("YEET");
+
     // UI activate
     event.target.classList.add(schedActive);
     event.target.classList.remove(schedInactive);
@@ -1847,6 +1849,14 @@ function highlightSchedule(event) {
       sched.classList.remove(schedActive);
       sched.classList.add(schedInactive);
     }
+  }
+
+  // handle schedule tab color change
+  const scheduleTab = document.querySelector("#schedule-toggle");
+  if (event.target.id != "schedule-1") {
+    scheduleTab.setAttribute("style", event.target.getAttribute("style"));
+  } else {
+    scheduleTab.removeAttribute("style");
   }
 }
 

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -36,6 +36,9 @@ const scheduleToggle = document.getElementById("schedule-toggle");
 const scheduleDropDownContent = document.getElementById(
   "schedule-dropdown-content"
 );
+const scheduleDropDownText = document.getElementById(
+  "schedule-dropdown-content-text"
+);
 const scheduleDropdownAdd = document.getElementById("schedule-dropdown-add");
 
 const scheduleLabels = document.getElementsByClassName("schedule-label");
@@ -1477,6 +1480,7 @@ function handleGlobalStateUpdate() {
   updateConflictCoursesRadio();
   updateScheduleMenu();
   updateScheduleTabTitle();
+  updateDropDownText();
 
   // Update course displays.
   updateCourseDisplays();
@@ -1531,6 +1535,7 @@ function addNewSchedule() {
   // handle new DOM elements
   appendScheduleRow(defaultPair);
   catchEvent(event);
+  updateDropDownText();
 
   // Update state
   writeStateToLocalStorage();
@@ -1755,6 +1760,10 @@ function updateScheduleTabTitle() {
       scheduleToggle.innerText = sched.name;
     }
   }
+}
+
+function updateDropDownText() {
+  scheduleDropDownText.innerText = `Your Schedules: ${gScheduleList.length}`;
 }
 
 function updateCourseDisplays() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1552,6 +1552,7 @@ function appendScheduleRow(schedule) {
   let checkBox = document.createElement("input");
   let deleteButton = document.createElement("i");
   let editButton = document.createElement("i");
+  let checkEditWrapper = document.createElement("div");
 
   checkLabel.id = `schedule-${scheduleId}-checkbox`;
   checkLabel.classList.add("schedule-label");
@@ -1580,11 +1581,14 @@ function appendScheduleRow(schedule) {
   editButton.addEventListener("click", editName);
   editButton.addEventListener("click", catchEvent);
 
+  checkEditWrapper.classList.add("schedule-checkbox-edit-wrapper");
+  checkEditWrapper.appendChild(checkLabel);
+  if (scheduleId !== "schedule-1") checkEditWrapper.appendChild(editButton);
+
   newSched.classList.add("schedule-element");
   newSched.classList.add("btn");
   newSched.id = scheduleId;
-  newSched.appendChild(checkLabel);
-  if (scheduleId !== "schedule-1") newSched.appendChild(editButton);
+  newSched.appendChild(checkEditWrapper);
   newSched.appendChild(newName);
   if (scheduleId !== "schedule-1") newSched.appendChild(deleteButton);
   newSched.addEventListener("click", selectSchedule);
@@ -1746,27 +1750,27 @@ function toggleCourseStarred(course) {
 function toggleScheduleChecked() {
   if (event.target.className === "schedule-checkbox") {
     const parent = event.target.parentNode;
-    const schedArr = parent.children;
-    const schedId = parent.parentNode.id;
+    const checkArr = parent.children;
+    const schedId = event.target.parentNode.parentNode.parentNode.id;
 
     // cannot uncheck currently selected schedule
     if (schedId !== gLastScheduleSelected) {
-      if (schedArr[1].classList.contains("ion-android-checkbox")) {
+      if (checkArr[1].classList.contains("ion-android-checkbox")) {
         // One schedule must be checked
         const numChecked = gSchedulesChecked.length;
         if (numChecked > 1) {
           gSchedulesChecked.splice(gSchedulesChecked.indexOf(schedId), 1);
           // Uncheck schedule in UI
-          schedArr[1].classList.remove("ion-android-checkbox");
-          schedArr[1].classList.add("ion-android-checkbox-outline-blank");
+          checkArr[1].classList.remove("ion-android-checkbox");
+          checkArr[1].classList.add("ion-android-checkbox-outline-blank");
         } else {
-          schedArr[0].checked = true;
+          checkArr[0].checked = true;
         }
       } else {
         gSchedulesChecked.push(schedId);
         // Check off schedule in UI
-        schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
-        schedArr[1].classList.add("ion-android-checkbox");
+        checkArr[1].classList.remove("ion-android-checkbox-outline-blank");
+        checkArr[1].classList.add("ion-android-checkbox");
       }
     }
   }
@@ -1832,7 +1836,7 @@ function defaultCheckSchedule(event) {
     // Only check if not already checked
     if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
       gSchedulesChecked.push(gLastScheduleSelected);
-      const checkBox = event.target.children[0].children[1];
+      const checkBox = event.target.children[0].children[0].children[1];
       checkBox.classList.remove("ion-android-checkbox-outline-blank");
       checkBox.classList.add("ion-android-checkbox");
     }

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1757,13 +1757,13 @@ function defaultCheckSchedule(event) {
 function updateScheduleTabTitle() {
   for (const sched of gScheduleList) {
     if (sched.id === gLastScheduleSelected) {
-      scheduleToggle.innerText = sched.name;
+      scheduleToggle.textContent = sched.name;
     }
   }
 }
 
 function updateDropDownText() {
-  scheduleDropDownText.innerText = `Your Schedules: ${gScheduleList.length}`;
+  scheduleDropDownText.textContent = `Your Schedules: ${gScheduleList.length}`;
 }
 
 function updateCourseDisplays() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -36,9 +36,6 @@ const scheduleToggle = document.getElementById("schedule-toggle");
 const scheduleDropDownContent = document.getElementById(
   "schedule-dropdown-content"
 );
-const scheduleDropDownText = document.getElementById(
-  "schedule-dropdown-content-text"
-);
 const scheduleDropdownAdd = document.getElementById("schedule-dropdown-add");
 
 const scheduleLabels = document.getElementsByClassName("schedule-label");
@@ -1209,14 +1206,6 @@ function updateScheduleMenu() {
   }
 }
 
-function updateScheduleSelectedStartup() {
-  const schedule = document.getElementById(`schedule${gLastScheduleSelected}`);
-  const schedArr = schedule.children[0].children;
-  schedArr[0].checked = true;
-  schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
-  schedArr[1].classList.add("ion-android-checkbox");
-}
-
 function updateTabToggle() {
   setEntityVisibility(scheduleColumn, gScheduleTabSelected);
   setButtonSelected(scheduleToggle, gScheduleTabSelected);
@@ -1466,7 +1455,6 @@ function handleGlobalStateUpdate() {
   updateConflictCoursesRadio();
   updateScheduleMenu();
   updateScheduleTabTitle();
-  updateDropDownText();
 
   // Update course displays.
   updateCourseDisplays();
@@ -1521,7 +1509,6 @@ function addNewSchedule() {
   // handle new DOM elements
   appendScheduleRow(defaultPair);
   catchEvent(event);
-  updateDropDownText();
 
   // Update state
   writeStateToLocalStorage();
@@ -1580,7 +1567,7 @@ function appendScheduleRow(schedule) {
 }
 
 function removeSchedule() {
-  alert("removeSchedule called");
+  console.log(event.target.parentNode);
 }
 
 function removeCourse(course) {
@@ -1770,10 +1757,6 @@ function updateScheduleTabTitle() {
       scheduleToggle.textContent = sched.name;
     }
   }
-}
-
-function updateDropDownText() {
-  scheduleDropDownText.textContent = `Your Schedules: ${gScheduleList.length}`;
 }
 
 function updateCourseDisplays() {
@@ -2367,7 +2350,6 @@ attachListeners();
 readStateFromLocalStorage();
 handleGlobalStateUpdate();
 retrieveCourseDataUntilSuccessful();
-updateScheduleSelectedStartup();
 
 /// Closing remarks
 // Local Variables:

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1452,7 +1452,22 @@ function addCourse(course) {
   course.selected = true;
   course.starred = false;
   gSelectedCourses.push(course);
+  addToSchedules(course);
   handleSelectedCoursesUpdate();
+}
+
+function addToSchedules(course) {
+  for (const schedule of gSchedulesSelected) {
+    if (schedule !== gLastScheduleSelected) {
+      let oldSchedule = readFromLocalStorage(
+        `schedulesSelected${schedule}`,
+        _.isArray,
+        []
+      );
+      oldSchedule.push(course);
+      localStorage.setItem(`schedulesSelected${schedule}`, oldSchedule);
+    }
+  }
 }
 
 function removeCourse(course) {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1268,7 +1268,7 @@ function updateTabToggle() {
   setButtonSelected(courseSearchToggle, !gScheduleTabSelected);
 
   // Necessary for overwriting boostrap colors
-  if (gScheduleTabSelected) {
+  if (gScheduleTabSelected && gLastScheduleSelected.id !== "schedule-1") {
     scheduleToggle.classList.add("change-tab-color");
   } else {
     scheduleToggle.classList.remove("change-tab-color");
@@ -2010,9 +2010,15 @@ function updateScheduleTabTitle() {
 }
 
 function updateScheduleColor() {
-  newColor = gLastScheduleSelected.color;
-  const hoverColor = shadeColor(newColor, -3);
-  changeCSSColors(mainSheetRules, newColor, hoverColor);
+  // default schedule
+  if (gLastScheduleSelected.id === "schedule-1") {
+    scheduleToggle.classList.remove("change-tab-color");
+    scheduleDropDownButton.classList.remove("change-dropdown-color");
+  } else {
+    const newColor = gLastScheduleSelected.color;
+    const hoverColor = shadeColor(newColor, -3);
+    changeCSSColors(mainSheetRules, newColor, hoverColor);
+  }
 }
 
 function updateCourseDisplays() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1609,7 +1609,6 @@ function removeSchedule() {
       gSchedulesChecked.splice(gSchedulesChecked.indexOf(sched.id), 1);
     }
   }
-
   // remove from UI
   const row = event.target.parentNode;
   row.parentNode.removeChild(row);
@@ -1619,47 +1618,50 @@ function removeSchedule() {
   // case where removing current schedule
   // change current schedule to default schedule
   if (id === gLastScheduleSelected) {
-    const defaultRow = document.getElementById("schedule-1");
-    gLastScheduleSelected = "schedule-1";
-    gSelectedCourses = upgradeSelectedCourses(
-      readFromLocalStorage(
-        "selectedCourses-" + gLastScheduleSelected,
-        _.isArray,
-        []
-      )
-    );
-
-    defaultRow.classList.add("btn-info");
-    defaultRow.classList.remove("btn-light");
-    if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
-      gSchedulesChecked.push(gLastScheduleSelected);
-      const checkBox = defaultRow.children[0].children[1];
-      checkBox.classList.remove("ion-android-checkbox-outline-blank");
-      checkBox.classList.add("ion-android-checkbox");
-    }
-    updateCourseDisplays();
-    updateScheduleTabTitle();
+    handleCurrentScheduleRemoval();
   }
 
   writeStateToLocalStorage();
 }
 
+function handleCurrentScheduleRemoval() {
+  const defaultRow = document.getElementById("schedule-1");
+  // update global var
+  gLastScheduleSelected = "schedule-1";
+  gSelectedCourses = upgradeSelectedCourses(
+    readFromLocalStorage(
+      "selectedCourses-" + gLastScheduleSelected,
+      _.isArray,
+      []
+    )
+  );
+  // highlight
+  defaultRow.classList.add("btn-info");
+  defaultRow.classList.remove("btn-light");
+  // check
+  if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
+    gSchedulesChecked.push(gLastScheduleSelected);
+    const checkBox = defaultRow.children[0].children[1];
+    checkBox.classList.remove("ion-android-checkbox-outline-blank");
+    checkBox.classList.add("ion-android-checkbox");
+  }
+  updateCourseDisplays();
+  updateScheduleTabTitle();
+}
+
 function editName() {
   const id = event.target.parentNode.id;
-
   const inputName = promptName();
   // User pressed cancel
   if (inputName === undefined) {
     return;
   }
-
   // change global var
   for (const sched of gScheduleList) {
     if (sched.id === id) {
       sched.name = inputName;
     }
   }
-
   // change UI
   const oldName = event.target.parentNode.childNodes[2];
   oldName.nodeValue = inputName;
@@ -1748,11 +1750,10 @@ function toggleScheduleChecked() {
     // cannot uncheck currently selected schedule
     if (schedId !== gLastScheduleSelected) {
       if (schedArr[1].classList.contains("ion-android-checkbox")) {
-        // Check first that at least one other schedule is still checked
+        // One schedule must be checked
         const numChecked = gSchedulesChecked.length;
         if (numChecked > 1) {
           gSchedulesChecked.splice(gSchedulesChecked.indexOf(schedId), 1);
-
           // Uncheck schedule in UI
           schedArr[1].classList.remove("ion-android-checkbox");
           schedArr[1].classList.add("ion-android-checkbox-outline-blank");
@@ -1761,7 +1762,6 @@ function toggleScheduleChecked() {
         }
       } else {
         gSchedulesChecked.push(schedId);
-
         // Check off schedule in UI
         schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
         schedArr[1].classList.add("ion-android-checkbox");
@@ -1827,7 +1827,7 @@ function defaultCheckSchedule(event) {
     event.target.className === "schedule-element btn btn-light" ||
     event.target.className === "schedule-element btn"
   ) {
-    // Check if not already checked
+    // Only check if not already checked
     if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
       gSchedulesChecked.push(gLastScheduleSelected);
       const checkBox = event.target.children[0].children[1];

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -334,6 +334,22 @@ function setButtonSelected(button, selected) {
   button.classList.remove(classRemoved);
 }
 
+function setScheduleSelected() {
+  const schedSelected = "btn-info";
+  const schedInactive = "btn-light";
+  let i;
+  for (i = 1; i <= 4; i++) {
+    let button = document.getElementById("schedule" + i);
+    if (i == gLastScheduleSelected) {
+      button.classList.add(schedSelected);
+      button.classList.remove(schedInactive);
+    } else {
+      button.classList.add(schedInactive);
+      button.classList.remove(schedSelected);
+    }
+  }
+}
+
 function removeEntityChildren(entity) {
   while (entity.hasChildNodes()) {
     entity.removeChild(entity.lastChild);
@@ -1582,6 +1598,8 @@ function checkSchedule() {
 
   updateCourseDisplays();
 
+  setScheduleSelected();
+
   writeStateToLocalStorage();
 }
 
@@ -2149,6 +2167,7 @@ function downloadICalFile() {
 attachListeners();
 readStateFromLocalStorage();
 handleGlobalStateUpdate();
+setScheduleSelected();
 retrieveCourseDataUntilSuccessful();
 
 /// Closing remarks

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -43,9 +43,6 @@ const scheduleDropdownAdd = document.getElementById(
   "schedule-dropdown-add-wrapper"
 );
 const scheduleDropDownButton = document.getElementById(
-  "schedule-dropdown-toggle"
-);
-const scheduleDropDownArrow = document.getElementById(
   "schedule-dropdown-toggle-btn"
 );
 
@@ -1545,14 +1542,14 @@ function addToSchedules(course) {
   for (const schedule of gSchedulesChecked) {
     if (schedule !== gLastScheduleSelected) {
       let oldSchedule = readFromLocalStorage(
-        "selectedCourses-" + schedule,
+        `selectedCourses-${schedule.id}`,
         _.isArray,
         []
       );
       if (!courseAlreadyAdded(course, oldSchedule)) {
         oldSchedule.push(course);
         localStorage.setItem(
-          "selectedCourses-" + schedule,
+          `selectedCourses-${schedule.id}`,
           JSON.stringify(oldSchedule)
         );
       }
@@ -1726,7 +1723,7 @@ function handleCurrentScheduleRemoval() {
   };
   gSelectedCourses = upgradeSelectedCourses(
     readFromLocalStorage(
-      "selectedCourses-" + gLastScheduleSelected.id,
+      `selectedCourses-${gLastScheduleSelected.id}`,
       _.isArray,
       []
     )
@@ -1880,13 +1877,20 @@ function selectSchedule() {
     event.target.className === "schedule-element btn"
   ) {
     // Switch current schedule
-    newId = event.target.id;
-    newColor = rgbToHex(event.target.style.backgroundColor);
-    newName = event.target.textContent;
-    gLastScheduleSelected = { name: newName, id: newId, color: newColor };
+    const newName = event.target.textContent;
+    const newId = event.target.id;
+    let newColor = event.target.style.backgroundColor;
+
+    // default clicked
+    if (newColor === "") {
+      gLastScheduleSelected = { name: newName, id: newId, color: "#007bff" };
+    } else {
+      newcolor = rgbToHex(newColor);
+      gLastScheduleSelected = { name: newName, id: newId, color: newColor };
+    }
     gSelectedCourses = upgradeSelectedCourses(
       readFromLocalStorage(
-        "selectedCourses-" + gLastScheduleSelected,
+        `selectedCourses-${gLastScheduleSelected.id}`,
         _.isArray,
         []
       )
@@ -1903,9 +1907,25 @@ function selectSchedule() {
 }
 
 function updateScheduleTabDisplay(event) {
-  const newColor = rgbToHex(event.target.style.backgroundColor);
-  const hoverColor = shadeColor(newColor, -3);
-  changeCSSColors(mainSheetRules, newColor, hoverColor);
+  let newColor = event.target.style.backgroundColor;
+  // default clicked
+  if (newColor === "") {
+    scheduleToggle.classList.remove("change-tab-color");
+    scheduleDropDownButton.classList.remove("change-dropdown-color");
+  } else {
+    if (!scheduleDropDownButton.classList.contains("change-dropdown-color")) {
+      scheduleDropDownButton.classList.add("change-dropdown-color");
+    }
+    if (
+      !scheduleToggle.classList.contains("change-tab-color") &&
+      gScheduleTabSelected
+    ) {
+      scheduleToggle.classList.add("change-tab-color");
+    }
+    newColor = rgbToHex(newColor);
+    const hoverColor = shadeColor(newColor, -3);
+    changeCSSColors(mainSheetRules, newColor, hoverColor);
+  }
 }
 
 function changeCSSColors(rules, newColor, hoverColor) {
@@ -2135,7 +2155,7 @@ function writeStateToLocalStorage() {
     JSON.stringify([gLastScheduleSelected])
   );
   localStorage.setItem(
-    "selectedCourses-" + gLastScheduleSelected,
+    `selectedCourses-${gLastScheduleSelected.id}`,
     JSON.stringify(gSelectedCourses)
   );
   localStorage.setItem("scheduleTabSelected", gScheduleTabSelected);
@@ -2231,7 +2251,7 @@ function readStateFromLocalStorage() {
   ]);
   gSelectedCourses = upgradeSelectedCourses(
     readFromLocalStorage(
-      "selectedCourses-" + gLastScheduleSelected.id,
+      `selectedCourses-${gLastScheduleSelected.id}`,
       _.isArray,
       []
     )

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -113,10 +113,10 @@ const importExportCopyButton = document.getElementById(
 
 // Persistent data.
 let gApiData = null;
+let gLastScheduleSelected = 1;
+let gSchedulesSelected = [1];
 let gSelectedCourses = [];
 let gScheduleTabSelected = false;
-let gLastScheduleSelected = 1;
-let gSchedulesSelected = [0];
 let gShowClosedCourses = true;
 let gHideAllConflictingCourses = false;
 let gHideStarredConflictingCourses = false;
@@ -825,10 +825,10 @@ function attachListeners() {
 
   courseSearchToggle.addEventListener("click", displayCourseSearchColumn);
   scheduleToggle.addEventListener("click", displayScheduleColumn);
-  schedule1.addEventListener("click", checkSchedule1);
-  schedule2.addEventListener("click", checkSchedule2);
-  schedule3.addEventListener("click", checkSchedule3);
-  schedule4.addEventListener("click", checkSchedule4);
+  schedule1.addEventListener("click", checkSchedule);
+  schedule2.addEventListener("click", checkSchedule);
+  schedule3.addEventListener("click", checkSchedule);
+  schedule4.addEventListener("click", checkSchedule);
   closedCoursesToggle.addEventListener("click", toggleClosedCourses);
   hideAllConflictingCoursesToggle.addEventListener(
     "click",
@@ -1545,20 +1545,29 @@ function displayScheduleColumn() {
   writeStateToLocalStorage();
 }
 
-function checkSchedule1() {
-  console.log("schedule 1 clicked");
-}
+function checkSchedule() {
+  const id = event.target.id;
+  if (id === "schedule1") {
+    gLastScheduleSelected = 1;
+  } else if (id === "schedule2") {
+    gLastScheduleSelected = 2;
+  } else if (id === "schedule3") {
+    gLastScheduleSelected = 3;
+  } else if (id === "schedule4") {
+    gLastScheduleSelected = 4;
+  }
 
-function checkSchedule2() {
-  console.log("schedule 2 clicked");
-}
+  gSelectedCourses = upgradeSelectedCourses(
+    readFromLocalStorage(
+      `selectedCourses${gLastScheduleSelected}`,
+      _.isArray,
+      []
+    )
+  );
 
-function checkSchedule3() {
-  console.log("schedule 3 clicked");
-}
+  updateCourseDisplays();
 
-function checkSchedule4() {
-  console.log("schedule 4 clicked");
+  writeStateToLocalStorage();
 }
 
 //// Course retrieval
@@ -1670,7 +1679,12 @@ async function retrieveCourseDataUntilSuccessful() {
 
 function writeStateToLocalStorage() {
   localStorage.setItem("apiData", JSON.stringify(gApiData));
-  localStorage.setItem("selectedCourses", JSON.stringify(gSelectedCourses));
+  localStorage.setItem("lastScheduleSelected", gLastScheduleSelected);
+  localStorage.setItem("schedulesSelected", gSchedulesSelected);
+  localStorage.setItem(
+    `selectedCourses${gLastScheduleSelected}`,
+    JSON.stringify(gSelectedCourses)
+  );
   localStorage.setItem("scheduleTabSelected", gScheduleTabSelected);
   localStorage.setItem("showClosedCourses", gShowClosedCourses);
   localStorage.setItem("hideAllConflictingCourses", gHideAllConflictingCourses);
@@ -1750,8 +1764,20 @@ function upgradeSelectedCourses(selectedCourses) {
 
 function readStateFromLocalStorage() {
   gApiData = readFromLocalStorage("apiData", _.isObject, null);
+  gLastScheduleSelected = readFromLocalStorage(
+    "lastScheduleSelected",
+    _.isNumber,
+    1
+  );
+  gSchedulesSelected = readFromLocalStorage("schedulesSelected", _.isArray, [
+    1
+  ]);
   gSelectedCourses = upgradeSelectedCourses(
-    readFromLocalStorage("selectedCourses", _.isArray, [])
+    readFromLocalStorage(
+      `selectedCourses${gLastScheduleSelected}`,
+      _.isArray,
+      []
+    )
   );
   gScheduleTabSelected = readFromLocalStorage(
     "scheduleTabSelected",

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1523,10 +1523,31 @@ function addNewSchedule() {
   console.log(event.target);
   let wrapper = document.getElementById("schedule-dropdown-content");
   let newSched = document.createElement("div");
-  let newName = document.createTextNode("Schedule" + gLastScheduleId);
+  let newName = document.createTextNode(
+    "ScheduleREEEEEEEEEEEEE" + gLastScheduleId
+  );
+  let checkLabel = document.createElement("label");
+  let checkIcon = document.createElement("i");
+  let checkBox = document.createElement("input");
+
+  checkLabel.id = "schedule-" + gLastScheduleId + "-checkbox";
+  checkLabel.classList.add("schedule-label");
+  checkLabel.addEventListener("change", toggleScheduleSelected);
+
+  checkIcon.classList.add("schedule-icon");
+  checkIcon.classList.add("icon");
+  checkIcon.classList.add("ion-android-checkbox-outline-blank");
+
+  checkBox.type = "checkbox";
+  checkBox.classList.add("schedule-checkbox");
+
+  checkLabel.appendChild(checkBox);
+  checkLabel.appendChild(checkIcon);
+
   newSched.classList.add("schedule-element");
   newSched.classList.add("btn");
   newSched.id = "schedule-" + gLastScheduleId;
+  newSched.appendChild(checkLabel);
   newSched.appendChild(newName);
   newSched.addEventListener("click", selectSchedule);
   wrapper.appendChild(newSched);

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -265,7 +265,6 @@ function readFromLocalStorage(key, pred, def) {
 }
 
 function catchEvent(event) {
-  console.log("CAUGHT");
   event.stopPropagation();
 }
 
@@ -1648,8 +1647,6 @@ function toggleScheduleSelected() {
     const schedArr = parent.children;
     const schedNum = Number(parent.id.charAt(9));
 
-    console.log("TOGGLE");
-    console.log(gLastScheduleSelected);
     if (schedArr[1].classList.contains("ion-android-checkbox")) {
       // Check first that at least one other schedule is still checked
       const numChecked = gSchedulesChecked.length;
@@ -1704,8 +1701,6 @@ function highlightSchedule(event) {
   // multischedules- highlights one schedule in the dropdown
   const schedActive = "btn-info";
   const schedInactive = "btn-light";
-  console.log("HIGHLIGHT");
-  console.log(gLastScheduleSelected);
   if (
     !event.target.classList.contains(schedActive) &&
     !event.target.classList.contains("schedule-checkbox")

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1889,7 +1889,6 @@ function selectSchedule() {
 
     // default clicked
     if (newColor === "") {
-      console.log("test");
       gLastScheduleSelected = { name: newName, id: newId, color: "#007bff" };
     } else {
       newColor = rgbToHex(newColor);
@@ -1919,6 +1918,7 @@ function updateScheduleTabDisplay(event) {
   if (newColor === "") {
     newColor = "#007bff";
   }
+  // Attach CSS classess for overriding Bootstrap colors
   if (!scheduleDropDownButton.classList.contains("change-dropdown-color")) {
     scheduleDropDownButton.classList.add("change-dropdown-color");
   }
@@ -1934,6 +1934,7 @@ function updateScheduleTabDisplay(event) {
 }
 
 function changeCSSColors(rules, newColor, hoverColor) {
+  // Find CSS rules and override with inputted color
   for (const rule of rules) {
     if (rule.selectorText === ".change-dropdown-color") {
       rule.style.setProperty("border-color", newColor, "important");
@@ -2012,11 +2013,7 @@ function defaultCheckSchedule(event) {
 }
 
 function updateScheduleTabTitle() {
-  for (const sched of gScheduleList) {
-    if (sched.id === gLastScheduleSelected.id) {
-      scheduleToggle.textContent = sched.name;
-    }
-  }
+  scheduleToggle.textContent = gLastScheduleSelected.name;
 }
 
 function updateScheduleColor() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -526,10 +526,10 @@ function getCourseColor(course, format = "hex") {
   return getRandomColor(hue, seed, format);
 }
 
-function getRandomColor(hue, seed, format = "hex") {
+function getRandomColor(hue, seed, format = "hex", luminosity = "light") {
   return randomColor({
     hue: hue,
-    luminosity: "light",
+    luminosity: luminosity,
     seed: seed,
     format
   });
@@ -1575,7 +1575,8 @@ function addNewSchedule() {
     color: getRandomColor(
       "random",
       CryptoJS.MD5(newId + inputName).toString(),
-      "hex"
+      "hex",
+      "dark"
     )
   };
   gScheduleList.push(defaultPair);

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1479,15 +1479,16 @@ function addCourse(course) {
 function addToSchedules(course) {
   for (const schedule of gSchedulesChecked) {
     if (schedule !== gLastScheduleSelected) {
+      console.log(schedule);
       let oldSchedule = readFromLocalStorage(
-        `selectedCourses-${schedule}`,
+        "selectedCourses-" + schedule,
         _.isArray,
         []
       );
       if (!courseAlreadyAdded(course, oldSchedule)) {
         oldSchedule.push(course);
         localStorage.setItem(
-          `selectedCourses-${schedule}`,
+          "selectedCourses-" + schedule,
           JSON.stringify(oldSchedule)
         );
       }
@@ -1508,7 +1509,7 @@ function addNewSchedule() {
   gLastScheduleId++;
   const defaultPair = {
     name: inputName,
-    id: `schedule-${gLastScheduleId}`
+    id: "schedule-" + gLastScheduleId
   };
   gScheduleList.push(defaultPair);
 
@@ -1752,15 +1753,16 @@ function selectSchedule() {
     highlightSchedule(event);
     defaultCheckSchedule(event);
     console.log(gLastScheduleSelected);
+    console.log("selectedCourses-" + gLastScheduleSelected);
     // Switch current schedule (some global var updated in defaultCheckSchedule)
     gSelectedCourses = upgradeSelectedCourses(
       readFromLocalStorage(
-        `selectedCourses-${gLastScheduleSelected}`,
+        "selectedCourses-" + gLastScheduleSelected,
         _.isArray,
         []
       )
     );
-    console.log(gSelectedCourses);
+
     console.log(gLastScheduleSelected);
     console.log(gSchedulesChecked);
     updateCourseDisplays();
@@ -1813,7 +1815,6 @@ function defaultCheckSchedule(event) {
     }
 
     gLastScheduleSelected = event.target.id;
-    writeStateToLocalStorage();
 
     // Check if not already checked
     if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
@@ -1973,7 +1974,7 @@ function writeStateToLocalStorage() {
     JSON.stringify([gLastScheduleSelected])
   );
   localStorage.setItem(
-    `selectedCourses-${gLastScheduleSelected}`,
+    "selectedCourses-" + gLastScheduleSelected,
     JSON.stringify(gSelectedCourses)
   );
   localStorage.setItem("scheduleTabSelected", gScheduleTabSelected);
@@ -2069,7 +2070,7 @@ function readStateFromLocalStorage() {
   ]);
   gSelectedCourses = upgradeSelectedCourses(
     readFromLocalStorage(
-      `selectedCourses-${gLastScheduleSelected}`,
+      "selectedCourses-" + gLastScheduleSelected,
       _.isArray,
       []
     )

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -848,7 +848,7 @@ function attachListeners() {
   schedule3.addEventListener("click", checkSchedule);
   schedule4.addEventListener("click", checkSchedule);
 
-  for (let label of scheduleLabels) {
+  for (const label of scheduleLabels) {
     label.addEventListener("change", toggleScheduleSelected);
   }
 
@@ -1211,8 +1211,8 @@ function getSearchTextFilters(filtersTextArray) {
 ///// DOM updates due to global state change
 
 function updateScheduleSelectedStartup() {
-  let schedule = document.getElementById("schedule" + gLastScheduleSelected);
-  let schedArr = schedule.children[0].children;
+  const schedule = document.getElementById("schedule" + gLastScheduleSelected);
+  const schedArr = schedule.children[0].children;
   schedArr[0].checked = true;
   schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
   schedArr[1].classList.add("ion-android-checkbox");
@@ -1574,11 +1574,11 @@ function toggleCourseStarred(course) {
 }
 
 function toggleScheduleSelected() {
-  let schedArr = event.target.parentNode.children;
+  const schedArr = event.target.parentNode.children;
   if (schedArr[1].classList.contains("ion-android-checkbox")) {
     // Check first that at least one other schedule is still checked
     let numChecked = 0;
-    for (let l of document.getElementsByClassName("schedule-checkbox")) {
+    for (const l of document.getElementsByClassName("schedule-checkbox")) {
       if (l.checked) numChecked++;
     }
     if (numChecked >= 1) {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1536,6 +1536,7 @@ function appendScheduleRow(schedule) {
   let checkLabel = document.createElement("label");
   let checkIcon = document.createElement("i");
   let checkBox = document.createElement("input");
+  let deleteButton = document.createElement("i");
 
   checkLabel.id = `schedule-${scheduleId}-checkbox`;
   checkLabel.classList.add("schedule-label");
@@ -1552,11 +1553,18 @@ function appendScheduleRow(schedule) {
   checkLabel.appendChild(checkBox);
   checkLabel.appendChild(checkIcon);
 
+  deleteButton.classList.add("icon");
+  deleteButton.classList.add("ion-close");
+  deleteButton.classList.add("schedule-delete-button");
+  deleteButton.addEventListener("click", removeSchedule);
+  deleteButton.addEventListener("click", catchEvent);
+
   newSched.classList.add("schedule-element");
   newSched.classList.add("btn");
   newSched.id = `schedule-${scheduleId}`;
   newSched.appendChild(checkLabel);
   newSched.appendChild(newName);
+  newSched.appendChild(deleteButton);
   newSched.addEventListener("click", selectSchedule);
   newSched.addEventListener("click", catchEvent);
   scheduleDropDownContent.appendChild(newSched);
@@ -1569,6 +1577,10 @@ function appendScheduleRow(schedule) {
     checkIcon.classList.remove("ion-android-checkbox-outline-blank");
     checkIcon.classList.add("ion-android-checkbox");
   }
+}
+
+function removeSchedule() {
+  alert("removeSchedule called");
 }
 
 function removeCourse(course) {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -342,22 +342,6 @@ function setButtonSelected(button, selected) {
   button.classList.remove(classRemoved);
 }
 
-function setScheduleSelected() {
-  const schedSelected = "btn-info";
-  const schedInactive = "btn-light";
-  let i;
-  for (i = 1; i <= 4; i++) {
-    let button = document.getElementById(`schedule${i}`);
-    if (i === gLastScheduleSelected) {
-      button.classList.add(schedSelected);
-      button.classList.remove(schedInactive);
-    } else {
-      button.classList.add(schedInactive);
-      button.classList.remove(schedSelected);
-    }
-  }
-}
-
 function removeEntityChildren(entity) {
   while (entity.hasChildNodes()) {
     entity.removeChild(entity.lastChild);
@@ -1680,6 +1664,7 @@ function toggleScheduleSelected() {
 }
 
 function selectSchedule() {
+  // Make sure checkbox is not activating event listener here
   highlightSchedule(event);
   defaultCheckSchedule(event);
 
@@ -1701,12 +1686,14 @@ function selectSchedule() {
 }
 
 function highlightSchedule(event) {
-  // multischedule new function - highlights one schedule in the dropdown
-  // intended to replace the old function "setScheduleSelected"
+  // multischedules- highlights one schedule in the dropdown
   const schedActive = "btn-info";
   const schedInactive = "btn-light";
 
-  if (!event.target.classList.contains(schedActive)) {
+  if (
+    !event.target.classList.contains(schedActive) &&
+    !event.target.classList.contains("schedule-checkbox")
+  ) {
     // if schedule isn't already active
 
     // UI activate
@@ -1784,49 +1771,6 @@ function displayScheduleColumn() {
   gScheduleTabSelected = true;
   updateTabToggle();
   writeStateToLocalStorage();
-}
-
-function checkSchedule() {
-  // Only check schedule when user clicked on schedule button (and not checkbox)
-  if (
-    event.target.className === "course-schedule-button-content btn btn-light" ||
-    event.target.className === "course-schedule-button-content btn btn-info"
-  ) {
-    // Uncheck previously selected schedule
-    if (gSchedulesChecked.includes(gLastScheduleSelected)) {
-      gSchedulesChecked.splice(
-        gSchedulesChecked.indexOf(gLastScheduleSelected),
-        1
-      );
-      const checkBox = document.getElementsByClassName(
-        "schedule-icon icon ion-android-checkbox"
-      )[0];
-      checkBox.classList.remove("ion-android-checkbox");
-      checkBox.classList.add("ion-android-checkbox-outline-blank");
-    }
-
-    // Switch current schedule
-    gLastScheduleSelected = Number(event.target.id.charAt(8));
-    gSelectedCourses = upgradeSelectedCourses(
-      readFromLocalStorage(
-        `selectedCourses${gLastScheduleSelected}`,
-        _.isArray,
-        []
-      )
-    );
-
-    // Check if not already checked
-    if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
-      gSchedulesChecked.push(gLastScheduleSelected);
-      const checkBox = event.target.children[0].children[1];
-      checkBox.classList.remove("ion-android-checkbox-outline-blank");
-      checkBox.classList.add("ion-android-checkbox");
-    }
-
-    updateCourseDisplays();
-    setScheduleSelected();
-    writeStateToLocalStorage();
-  }
 }
 
 //// Course retrieval
@@ -2399,7 +2343,6 @@ function downloadICalFile() {
 attachListeners();
 readStateFromLocalStorage();
 handleGlobalStateUpdate();
-setScheduleSelected();
 retrieveCourseDataUntilSuccessful();
 updateScheduleSelectedStartup();
 

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -362,7 +362,7 @@ function removeEntityChildren(entity) {
 ///// Course property queries
 
 function isCourseClosed(course) {
-  return course.courseEnrollmentStatus == "closed";
+  return course.courseEnrollmentStatus === "closed";
 }
 
 function courseToString(course) {
@@ -625,13 +625,13 @@ function coursePassesDayFilter(course, inputString) {
       const difference2 = new Set(
         [...inputDays].filter(x => !courseDays.has(x))
       );
-      return difference1.size == 0 && difference2.size == 0;
+      return difference1.size === 0 && difference2.size === 0;
     case "<":
       // courseDays is a proper subset of inputDays
-      return courseDays.subSet(inputDays) && inputDays.size != courseDays.size;
+      return courseDays.subSet(inputDays) && inputDays.size !== courseDays.size;
     case ">":
       // inputDays is a proper subset of courseDays
-      return inputDays.subSet(courseDays) && inputDays.size != courseDays.size;
+      return inputDays.subSet(courseDays) && inputDays.size !== courseDays.size;
     default:
       return false;
   }
@@ -1640,6 +1640,8 @@ function checkSchedule() {
       checkBox.classList.remove("ion-android-checkbox");
       checkBox.classList.add("ion-android-checkbox-outline-blank");
     }
+
+    // Switch current schedule
     gLastScheduleSelected = Number(event.target.id.charAt(8));
     gSelectedCourses = upgradeSelectedCourses(
       readFromLocalStorage(
@@ -1648,8 +1650,8 @@ function checkSchedule() {
         []
       )
     );
+
     // Check if not already checked
-    console.log(event.target.children[0].children[1]);
     if (!gSchedulesSelected.includes(gLastScheduleSelected)) {
       gSchedulesSelected.push(gLastScheduleSelected);
       const checkBox = event.target.children[0].children[1];

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1519,6 +1519,7 @@ function handleGlobalStateUpdate() {
   updateConflictCoursesRadio();
   updateScheduleMenu();
   updateScheduleTabTitle();
+  updateScheduleColor();
 
   // Update course displays.
   updateCourseDisplays();
@@ -1986,6 +1987,12 @@ function updateScheduleTabTitle() {
       scheduleToggle.textContent = sched.name;
     }
   }
+}
+
+function updateScheduleColor() {
+  newColor = gLastScheduleSelected.color;
+  const hoverColor = shadeColor(newColor, -3);
+  changeCSSColors(mainSheetRules, newColor, hoverColor);
 }
 
 function updateCourseDisplays() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1885,7 +1885,7 @@ function selectSchedule() {
     if (newColor === "") {
       gLastScheduleSelected = { name: newName, id: newId, color: "#007bff" };
     } else {
-      newcolor = rgbToHex(newColor);
+      newColor = rgbToHex(newColor);
       gLastScheduleSelected = { name: newName, id: newId, color: newColor };
     }
     gSelectedCourses = upgradeSelectedCourses(
@@ -1910,46 +1910,50 @@ function updateScheduleTabDisplay(event) {
   let newColor = event.target.style.backgroundColor;
   // default clicked
   if (newColor === "") {
-    scheduleToggle.classList.remove("change-tab-color");
-    scheduleDropDownButton.classList.remove("change-dropdown-color");
-  } else {
-    if (!scheduleDropDownButton.classList.contains("change-dropdown-color")) {
-      scheduleDropDownButton.classList.add("change-dropdown-color");
-    }
-    if (
-      !scheduleToggle.classList.contains("change-tab-color") &&
-      gScheduleTabSelected
-    ) {
-      scheduleToggle.classList.add("change-tab-color");
-    }
-    newColor = rgbToHex(newColor);
-    const hoverColor = shadeColor(newColor, -3);
-    changeCSSColors(mainSheetRules, newColor, hoverColor);
+    newColor = "#007bff";
   }
+  if (!scheduleDropDownButton.classList.contains("change-dropdown-color")) {
+    scheduleDropDownButton.classList.add("change-dropdown-color");
+  }
+  if (
+    !scheduleToggle.classList.contains("change-tab-color") &&
+    gScheduleTabSelected
+  ) {
+    scheduleToggle.classList.add("change-tab-color");
+  }
+  if (newColor.charAt(0) !== "#") newColor = rgbToHex(newColor);
+  const hoverColor = shadeColor(newColor, -3);
+  changeCSSColors(mainSheetRules, newColor, hoverColor);
 }
 
 function changeCSSColors(rules, newColor, hoverColor) {
   for (const rule of rules) {
-    // console.log(rule);
     if (rule.selectorText === ".change-dropdown-color") {
-      rule.style["border-color"] = newColor;
-      rule.style.color = newColor;
+      rule.style.setProperty("border-color", newColor, "important");
+      rule.style.setProperty("color", newColor, "important");
     } else if (rule.selectorText === ".change-tab-color") {
-      rule.style["background-color"] = newColor;
+      rule.style.setProperty("background-color", newColor, "important");
+      if (newColor === "#007bff")
+        rule.style.setProperty("color", "white", "important");
+      else rule.style.setProperty("color", "black", "important");
     } else if (
       rule.selectorText ===
       ".change-dropdown-color:hover, .change-dropdown-color:focus, .change-dropdown-color:active, .change-dropdown-color.active, .open > .dropdown-toggle.change-dropdown-color .show > .dropdown-toggle.change-dropdown-color"
     ) {
-      // must set these to !important somehow
-      rule.style["background-color"] = newColor;
-      rule.style["border-color"] = newColor;
-      rule.style["box-shadow"] = "none";
-      rule.style["outline"] = "none";
+      rule.style.setProperty("background-color", newColor, "important");
+      rule.style.setProperty("border-color", newColor, "important");
+      rule.style.setProperty("color", "white", "important");
+      rule.style.setProperty("box-shadow", "none", "important");
+      rule.style.setProperty("outline", "none", "important");
     } else if (
       rule.selectorText ===
       ".change-tab-color:hover, .change-tab-color:focus, .change-tab-color:active, .change-tab-color.active, .open > .dropdown-toggle.change-tab-color"
     ) {
-      rule.style["background-color"] = hoverColor;
+      rule.style.setProperty("background-color", hoverColor, "important");
+      rule.style.setProperty("box-shadow", "none", "important");
+      if (newColor === "#007bff")
+        rule.style.setProperty("color", "white", "important");
+      else rule.style.setProperty("color", "black", "important");
     }
   }
 }
@@ -2009,15 +2013,9 @@ function updateScheduleTabTitle() {
 }
 
 function updateScheduleColor() {
-  // default schedule
-  if (gLastScheduleSelected.id === "schedule-1") {
-    scheduleToggle.classList.remove("change-tab-color");
-    scheduleDropDownButton.classList.remove("change-dropdown-color");
-  } else {
-    const newColor = rgbToHex(gLastScheduleSelected.color);
-    const hoverColor = shadeColor(newColor, -3);
-    changeCSSColors(mainSheetRules, newColor, hoverColor);
-  }
+  const newColor = gLastScheduleSelected.color;
+  const hoverColor = shadeColor(newColor, -3);
+  changeCSSColors(mainSheetRules, newColor, hoverColor);
 }
 
 function updateCourseDisplays() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -795,10 +795,10 @@ function computeCreditCountDescription(schedule) {
 
 //// Global state queries
 
-function courseAlreadyAdded(course) {
+function courseAlreadyAdded(course, selectedCoursesList) {
   return _.some(selectedCourse => {
     return selectedCourse.courseCode === course.courseCode;
-  }, gSelectedCourses);
+  }, selectedCoursesList);
 }
 
 /// API retrieval
@@ -1280,7 +1280,7 @@ function rerenderCourseSearchResults() {
     ++index
   ) {
     const course = gApiData.data.courses[gFilteredCourseKeys[index]];
-    const alreadyAdded = courseAlreadyAdded(course);
+    const alreadyAdded = courseAlreadyAdded(course, gSelectedCourses);
     const entity = createCourseEntity(course, { alreadyAdded });
     entity.style.top = "" + gCourseEntityHeight * index + "px";
     courseSearchResultsList.appendChild(entity);
@@ -1445,7 +1445,7 @@ function handleGlobalStateUpdate() {
 //// Global state mutation
 
 function addCourse(course) {
-  if (courseAlreadyAdded(course)) {
+  if (courseAlreadyAdded(course, gSelectedCourses)) {
     return;
   }
   course = deepCopy(course);
@@ -1464,8 +1464,10 @@ function addToSchedules(course) {
         _.isArray,
         []
       );
-      oldSchedule.push(course);
-      localStorage.setItem(`schedulesSelected${schedule}`, oldSchedule);
+      if (!courseAlreadyAdded(course, oldSchedule)) {
+        oldSchedule.push(course);
+        localStorage.setItem(`schedulesSelected${schedule}`, oldSchedule);
+      }
     }
   }
 }

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1675,15 +1675,30 @@ function toggleScheduleSelected() {
 }
 
 function selectSchedule() {
+  // Switch current schedule and update global variables
+  gLastScheduleSelected = Number(event.target.id.charAt(9));
+  gSelectedCourses = upgradeSelectedCourses(
+    readFromLocalStorage(
+      `selectedCourses${gLastScheduleSelected}`,
+      _.isArray,
+      []
+    )
+  );
+
+  updateCourseDisplays();
+  writeStateToLocalStorage();
+
+  highlightSchedule(event);
+
+  // prevent dropdown menu from closing
+  catchEvent(event);
+}
+
+function highlightSchedule(event) {
   // multischedule new function - highlights one schedule in the dropdown
   // intended to replace the old function "setScheduleSelected"
   const schedActive = "btn-info";
   const schedInactive = "btn-light";
-
-  // Update global var and state
-  const scheduleId = event.target.id.charAt(9);
-  gLastScheduleSelected = Number(scheduleId);
-  writeStateToLocalStorage();
 
   if (!event.target.classList.contains(schedActive)) {
     // if schedule isn't already active
@@ -1700,9 +1715,6 @@ function selectSchedule() {
       sched.classList.add(schedInactive);
     }
   }
-
-  // prevent dropdown menu from closing
-  catchEvent(event);
 }
 
 function updateCourseDisplays() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1567,7 +1567,24 @@ function appendScheduleRow(schedule) {
 }
 
 function removeSchedule() {
-  console.log(event.target.parentNode);
+  // only remove if at least one remains
+
+  const id = Number(event.target.parentNode.id.charAt(9));
+
+  // remove from global var
+  for (const sched of gScheduleList) {
+    if (sched.id === id) {
+      gScheduleList.splice(gScheduleList.indexOf(sched, id));
+    }
+  }
+
+  // remove from UI
+  const row = event.target.parentNode;
+  row.parentNode.removeChild(row);
+
+  catchEvent(event);
+
+  writeStateToLocalStorage();
 }
 
 function removeCourse(course) {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -33,6 +33,7 @@ filterInequalities = ["<=", ">=", "<", ">", "="];
 
 const courseSearchToggle = document.getElementById("course-search-toggle");
 const scheduleToggle = document.getElementById("schedule-toggle");
+const scheduleDropdownAdd = document.getElementById("schedule-dropdown-add");
 
 const schedule1 = document.getElementById("schedule1");
 const schedule2 = document.getElementById("schedule2");
@@ -40,6 +41,7 @@ const schedule3 = document.getElementById("schedule3");
 const schedule4 = document.getElementById("schedule4");
 
 const scheduleLabels = document.getElementsByClassName("schedule-label");
+const scheduleElements = document.getElementsByClassName("schedule-element");
 
 const closedCoursesToggle = document.getElementById("closed-courses-toggle");
 const hideAllConflictingCoursesToggle = document.getElementById(
@@ -116,6 +118,7 @@ const importExportCopyButton = document.getElementById(
 // Persistent data.
 let gApiData = null;
 let gLastScheduleSelected = 1;
+let gLastScheduleId = 1;
 let gSchedulesSelected = [gLastScheduleSelected];
 let gSelectedCourses = [];
 let gScheduleTabSelected = false;
@@ -843,11 +846,15 @@ function attachListeners() {
 
   courseSearchToggle.addEventListener("click", displayCourseSearchColumn);
   scheduleToggle.addEventListener("click", displayScheduleColumn);
+  scheduleDropdownAdd.addEventListener("click", addNewSchedule);
   schedule1.addEventListener("click", checkSchedule);
   schedule2.addEventListener("click", checkSchedule);
   schedule3.addEventListener("click", checkSchedule);
   schedule4.addEventListener("click", checkSchedule);
 
+  for (const sched of scheduleElements) {
+    sched.addEventListener("click", selectSchedule);
+  }
   for (const label of scheduleLabels) {
     label.addEventListener("change", toggleScheduleSelected);
   }
@@ -1506,6 +1513,27 @@ function addToSchedules(course) {
   }
 }
 
+function addNewSchedule() {
+  // Adds a new schedule to the dropdown list.
+
+  // update global var
+  gLastScheduleId++;
+
+  // handle new DOM elements
+  console.log(event.target);
+  let wrapper = document.getElementById("schedule-dropdown-content");
+  let newSched = document.createElement("div");
+  let newName = document.createTextNode("Schedule" + gLastScheduleId);
+  newSched.classList.add("schedule-element");
+  newSched.classList.add("btn");
+  newSched.id = "schedule-" + gLastScheduleId;
+  newSched.appendChild(newName);
+  newSched.addEventListener("click", selectSchedule);
+  wrapper.appendChild(newSched);
+
+  event.stopPropagation();
+}
+
 function removeCourse(course) {
   gSelectedCourses.splice(gSelectedCourses.indexOf(course), 1);
   handleSelectedCoursesUpdate();
@@ -1600,6 +1628,31 @@ function toggleScheduleSelected() {
     schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
     schedArr[1].classList.add("ion-android-checkbox");
   }
+}
+
+function selectSchedule() {
+  // multischedule new function - highlights one schedule in the dropdown
+  // intended to replace the old function "setScheduleSelected"
+  const schedActive = "btn-info";
+  const schedInactive = "btn-light";
+  if (!event.target.classList.contains(schedActive)) {
+    // if schedule isn't already active
+
+    // UI activate
+    event.target.classList.add(schedActive);
+    event.target.classList.remove(schedInactive);
+  }
+  // loop through remaining schedules and un-select them
+  for (sched of scheduleElements) {
+    if (sched.id != event.target.id) {
+      // UI de-activate
+      sched.classList.remove(schedActive);
+      sched.classList.add(schedInactive);
+    }
+  }
+
+  // prevent dropdown menu from closing
+  event.stopPropagation();
 }
 
 function updateCourseDisplays() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1930,7 +1930,7 @@ function updateScheduleTabDisplay(event) {
 
 function changeCSSColors(rules, newColor, hoverColor) {
   for (const rule of rules) {
-    //console.log(rule);
+    // console.log(rule);
     if (rule.selectorText === ".change-dropdown-color") {
       rule.style["border-color"] = newColor;
       rule.style.color = newColor;
@@ -1940,7 +1940,6 @@ function changeCSSColors(rules, newColor, hoverColor) {
       rule.selectorText ===
       ".change-dropdown-color:hover, .change-dropdown-color:focus, .change-dropdown-color:active, .change-dropdown-color.active, .open > .dropdown-toggle.change-dropdown-color .show > .dropdown-toggle.change-dropdown-color"
     ) {
-      console.log("correct");
       // must set these to !important somehow
       rule.style["background-color"] = newColor;
       rule.style["border-color"] = newColor;
@@ -2015,7 +2014,7 @@ function updateScheduleColor() {
     scheduleToggle.classList.remove("change-tab-color");
     scheduleDropDownButton.classList.remove("change-dropdown-color");
   } else {
-    const newColor = gLastScheduleSelected.color;
+    const newColor = rgbToHex(gLastScheduleSelected.color);
     const hoverColor = shadeColor(newColor, -3);
     changeCSSColors(mainSheetRules, newColor, hoverColor);
   }

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -265,6 +265,7 @@ function readFromLocalStorage(key, pred, def) {
 }
 
 function catchEvent(event) {
+  console.log("CAUGHT");
   event.stopPropagation();
 }
 
@@ -837,10 +838,12 @@ function attachListeners() {
 
   for (const sched of scheduleElements) {
     sched.addEventListener("click", selectSchedule);
+    sched.addEventListener("click", catchEvent);
   }
 
   for (const label of scheduleLabels) {
     label.addEventListener("change", toggleScheduleSelected);
+    label.addEventListener("change", catchEvent);
   }
 
   closedCoursesToggle.addEventListener("click", toggleClosedCourses);
@@ -1538,6 +1541,7 @@ function appendScheduleRow(schedule) {
   checkLabel.id = `schedule-${scheduleId}-checkbox`;
   checkLabel.classList.add("schedule-label");
   checkLabel.addEventListener("change", toggleScheduleSelected);
+  checkLabel.addEventListener("change", catchEvent);
 
   checkIcon.classList.add("schedule-icon");
   checkIcon.classList.add("icon");
@@ -1555,6 +1559,7 @@ function appendScheduleRow(schedule) {
   newSched.appendChild(checkLabel);
   newSched.appendChild(newName);
   newSched.addEventListener("click", selectSchedule);
+  newSched.addEventListener("click", catchEvent);
   scheduleDropDownContent.appendChild(newSched);
 
   if (scheduleId === gLastScheduleSelected) {
@@ -1638,58 +1643,69 @@ function toggleCourseStarred(course) {
 }
 
 function toggleScheduleSelected() {
-  const parent = event.target.parentNode;
-  const schedArr = parent.children;
-  const schedNum = Number(parent.id.charAt(9));
+  if (!event.target.classList.contains("schedule-label")) {
+    const parent = event.target.parentNode;
+    const schedArr = parent.children;
+    const schedNum = Number(parent.id.charAt(9));
 
-  if (schedArr[1].classList.contains("ion-android-checkbox")) {
-    // Check first that at least one other schedule is still checked
-    const numChecked = gSchedulesChecked.length;
-    if (numChecked > 1) {
-      gSchedulesChecked.splice(gSchedulesChecked.indexOf(schedNum), 1);
+    console.log("TOGGLE");
+    console.log(gLastScheduleSelected);
+    if (schedArr[1].classList.contains("ion-android-checkbox")) {
+      // Check first that at least one other schedule is still checked
+      const numChecked = gSchedulesChecked.length;
+      if (numChecked > 1) {
+        gSchedulesChecked.splice(gSchedulesChecked.indexOf(schedNum), 1);
 
-      // Uncheck schedule in UI
-      schedArr[1].classList.remove("ion-android-checkbox");
-      schedArr[1].classList.add("ion-android-checkbox-outline-blank");
+        // Uncheck schedule in UI
+        schedArr[1].classList.remove("ion-android-checkbox");
+        schedArr[1].classList.add("ion-android-checkbox-outline-blank");
+      } else {
+        schedArr[0].checked = true;
+      }
     } else {
-      schedArr[0].checked = true;
-    }
-  } else {
-    gSchedulesChecked.push(schedNum);
+      gSchedulesChecked.push(schedNum);
 
-    // Check off schedule in UI
-    schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
-    schedArr[1].classList.add("ion-android-checkbox");
+      // Check off schedule in UI
+      schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
+      schedArr[1].classList.add("ion-android-checkbox");
+    }
+
+    // prevent dropdown from closing
+    // catchEvent(event);
   }
 }
 
 function selectSchedule() {
   // Make sure checkbox is not activating event listener here
-  highlightSchedule(event);
-  defaultCheckSchedule(event);
+  if (
+    !event.target.classList.contains("schedule-checkbox") &&
+    !event.target.classList.contains("icon") &&
+    !event.target.classList.contains("schedule-label")
+  ) {
+    highlightSchedule(event);
+    defaultCheckSchedule(event);
 
-  // Switch current schedule (some global var updated in defaultCheckSchedule)
-  gSelectedCourses = upgradeSelectedCourses(
-    readFromLocalStorage(
-      `selectedCourses${gLastScheduleSelected}`,
-      _.isArray,
-      []
-    )
-  );
+    // Switch current schedule (some global var updated in defaultCheckSchedule)
+    gSelectedCourses = upgradeSelectedCourses(
+      readFromLocalStorage(
+        `selectedCourses${gLastScheduleSelected}`,
+        _.isArray,
+        []
+      )
+    );
 
-  // prevent dropdown menu from closing
-  catchEvent(event);
-
-  updateCourseDisplays();
-  updateScheduleTabTitle();
-  writeStateToLocalStorage();
+    updateCourseDisplays();
+    updateScheduleTabTitle();
+    writeStateToLocalStorage();
+  }
 }
 
 function highlightSchedule(event) {
   // multischedules- highlights one schedule in the dropdown
   const schedActive = "btn-info";
   const schedInactive = "btn-light";
-
+  console.log("HIGHLIGHT");
+  console.log(gLastScheduleSelected);
   if (
     !event.target.classList.contains(schedActive) &&
     !event.target.classList.contains("schedule-checkbox")

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1567,11 +1567,19 @@ function toggleCourseStarred(course) {
 
 function toggleScheduleSelected() {
   let schedArr = event.target.parentNode.children;
-  console.log(schedArr);
-  console.log("hi");
   if (schedArr[1].classList.contains("ion-android-checkbox")) {
-    schedArr[1].classList.remove("ion-android-checkbox");
-    schedArr[1].classList.add("ion-android-checkbox-outline-blank");
+    // Check first that at least one other schedule is still checked
+    let numChecked = 0;
+    for (let l of document.getElementsByClassName("schedule-checkbox")) {
+      if (l.checked) numChecked++;
+    }
+    console.log(numChecked);
+    if (numChecked >= 1) {
+      schedArr[1].classList.remove("ion-android-checkbox");
+      schedArr[1].classList.add("ion-android-checkbox-outline-blank");
+    } else {
+      schedArr[0].checked = true;
+    }
   } else {
     schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
     schedArr[1].classList.add("ion-android-checkbox");

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1601,12 +1601,23 @@ function appendScheduleRow(schedule) {
   else newSched.appendChild(fakeDelete);
   newSched.addEventListener("click", selectSchedule);
   newSched.addEventListener("click", catchEvent);
+
+  if (scheduleId != "schedule-1") {
+    let hue = "random";
+    let seed = CryptoJS.MD5(scheduleId + newName).toString();
+
+    let newColor = getRandomColor(hue, seed, "hex");
+    newSched.style.backgroundColor = newColor;
+  } else {
+    newSched.classList.add("btn-primary");
+  }
+
   scheduleDropDownContent.appendChild(newSched);
 
   if (scheduleId === gLastScheduleSelected) {
     // highlight
-    newSched.classList.add("btn-info");
-    newSched.classList.remove("btn-light");
+    newSched.classList.add("schedule-active");
+    newSched.classList.remove("schedule-inactive");
     // check
     checkIcon.classList.remove("ion-android-checkbox-outline-blank");
     checkIcon.classList.add("ion-android-checkbox");
@@ -1650,12 +1661,12 @@ function handleCurrentScheduleRemoval() {
     )
   );
   // highlight
-  defaultRow.classList.add("btn-info");
-  defaultRow.classList.remove("btn-light");
+  defaultRow.classList.add("schedule-active");
+  defaultRow.classList.remove("schedule-inactive");
   // check
   if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
     gSchedulesChecked.push(gLastScheduleSelected);
-    const checkBox = defaultRow.children[0].children[1];
+    const checkBox = defaultRow.children[0].children[0].children[1];
     checkBox.classList.remove("ion-android-checkbox-outline-blank");
     checkBox.classList.add("ion-android-checkbox");
   }
@@ -1664,7 +1675,7 @@ function handleCurrentScheduleRemoval() {
 }
 
 function editName() {
-  const id = event.target.parentNode.id;
+  const id = event.target.parentNode.parentNode.id;
   const inputName = promptName();
   // User pressed cancel
   if (inputName === undefined) {
@@ -1672,12 +1683,13 @@ function editName() {
   }
   // change global var
   for (const sched of gScheduleList) {
+    console.log(sched.name);
     if (sched.id === id) {
       sched.name = inputName;
     }
   }
   // change UI
-  const oldName = event.target.parentNode.childNodes[2];
+  const oldName = event.target.parentNode.parentNode.childNodes[1];
   oldName.nodeValue = inputName;
 
   catchEvent(event);
@@ -1786,8 +1798,12 @@ function toggleScheduleChecked() {
 
 function selectSchedule() {
   if (
-    event.target.className === "schedule-element btn btn-info" ||
-    event.target.className === "schedule-element btn btn-light" ||
+    event.target.className === "schedule-element btn schedule-active" ||
+    event.target.className === "schedule-element btn schedule-inactive" ||
+    event.target.className ===
+      "schedule-element btn btn-primary schedule-active" ||
+    event.target.className ===
+      "schedule-element btn btn-primary schedule-inactive" ||
     event.target.className === "schedule-element btn"
   ) {
     // Switch current schedule
@@ -1811,14 +1827,15 @@ function selectSchedule() {
 
 function highlightSchedule(event) {
   // multischedules- highlights one schedule in the dropdown
-  const schedActive = "btn-info";
-  const schedInactive = "btn-light";
+  const schedActive = "schedule-active";
+  const schedInactive = "schedule-inactive";
+  console.log("LITT");
   if (
     !event.target.classList.contains(schedActive) &&
     !event.target.classList.contains("schedule-checkbox")
   ) {
     // if schedule isn't already active
-
+    console.log("YEET");
     // UI activate
     event.target.classList.add(schedActive);
     event.target.classList.remove(schedInactive);
@@ -1837,8 +1854,12 @@ function defaultCheckSchedule(event) {
   // every time user switches to a different schedule, current schedule should be checked
   // Only check schedule when user clicked on schedule button (and not checkbox)
   if (
-    event.target.className === "schedule-element btn btn-info" ||
-    event.target.className === "schedule-element btn btn-light" ||
+    event.target.className === "schedule-element btn schedule-active" ||
+    event.target.className === "schedule-element btn schedule-inactive" ||
+    event.target.className ===
+      "schedule-element btn btn-primary schedule-active" ||
+    event.target.className ===
+      "schedule-element btn btn-primary schedule-inactive" ||
     event.target.className === "schedule-element btn"
   ) {
     // Only check if not already checked

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1616,6 +1616,31 @@ function removeSchedule() {
 
   catchEvent(event);
 
+  // case where removing current schedule
+  // change current schedule to default schedule
+  if (id === gLastScheduleSelected) {
+    const defaultRow = document.getElementById("schedule-1");
+    gLastScheduleSelected = "schedule-1";
+    gSelectedCourses = upgradeSelectedCourses(
+      readFromLocalStorage(
+        "selectedCourses-" + gLastScheduleSelected,
+        _.isArray,
+        []
+      )
+    );
+
+    defaultRow.classList.add("btn-info");
+    defaultRow.classList.remove("btn-light");
+    if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
+      gSchedulesChecked.push(gLastScheduleSelected);
+      const checkBox = defaultRow.children[0].children[1];
+      checkBox.classList.remove("ion-android-checkbox-outline-blank");
+      checkBox.classList.add("ion-android-checkbox");
+    }
+    updateCourseDisplays();
+    updateScheduleTabTitle();
+  }
+
   writeStateToLocalStorage();
 }
 
@@ -1796,17 +1821,14 @@ function highlightSchedule(event) {
 
 function defaultCheckSchedule(event) {
   // every time user switches to a different schedule, current schedule should be checked
-  console.log(event.target);
   // Only check schedule when user clicked on schedule button (and not checkbox)
   if (
     event.target.className === "schedule-element btn btn-info" ||
     event.target.className === "schedule-element btn btn-light" ||
     event.target.className === "schedule-element btn"
   ) {
-    console.log("should check");
     // Check if not already checked
     if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
-      console.log("checked for real");
       gSchedulesChecked.push(gLastScheduleSelected);
       const checkBox = event.target.children[0].children[1];
       checkBox.classList.remove("ion-android-checkbox-outline-blank");

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -39,6 +39,8 @@ const schedule2 = document.getElementById("schedule2");
 const schedule3 = document.getElementById("schedule3");
 const schedule4 = document.getElementById("schedule4");
 
+const scheduleLabels = document.getElementsByClassName("schedule-label");
+
 const closedCoursesToggle = document.getElementById("closed-courses-toggle");
 const hideAllConflictingCoursesToggle = document.getElementById(
   "all-conflicting-courses-toggle"
@@ -845,6 +847,11 @@ function attachListeners() {
   schedule2.addEventListener("click", checkSchedule);
   schedule3.addEventListener("click", checkSchedule);
   schedule4.addEventListener("click", checkSchedule);
+
+  for (let label of scheduleLabels) {
+    label.addEventListener("change", toggleScheduleSelected);
+  }
+
   closedCoursesToggle.addEventListener("click", toggleClosedCourses);
   hideAllConflictingCoursesToggle.addEventListener(
     "click",
@@ -1556,6 +1563,19 @@ function toggleCourseStarred(course) {
   course.starred = !course.starred;
   updateCourseDisplays();
   writeStateToLocalStorage();
+}
+
+function toggleScheduleSelected() {
+  let schedArr = event.target.parentNode.children;
+  console.log(schedArr);
+  console.log("hi");
+  if (schedArr[1].classList.contains("ion-android-checkbox")) {
+    schedArr[1].classList.remove("ion-android-checkbox");
+    schedArr[1].classList.add("ion-android-checkbox-outline-blank");
+  } else {
+    schedArr[1].classList.remove("ion-android-checkbox-outline-blank");
+    schedArr[1].classList.add("ion-android-checkbox");
+  }
 }
 
 function updateCourseDisplays() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1706,7 +1706,7 @@ function removeSchedule() {
 
   // case where removing current schedule
   // change current schedule to default schedule
-  if (id === gLastScheduleSelecte.id) {
+  if (id === gLastScheduleSelected.id) {
     handleCurrentScheduleRemoval();
   }
 
@@ -1738,6 +1738,7 @@ function handleCurrentScheduleRemoval() {
     checkBox.classList.remove("ion-android-checkbox-outline-blank");
     checkBox.classList.add("ion-android-checkbox");
   }
+  updateScheduleColor();
   updateCourseDisplays();
   updateScheduleTabTitle();
 }

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -133,7 +133,7 @@ let gLastScheduleSelected = {
   color: "#007bff"
 };
 let gLastScheduleId = 1;
-let gSchedulesChecked = [gLastScheduleSelected];
+let gSchedulesChecked = [gLastScheduleSelected.id];
 let gSelectedCourses = [];
 let gScheduleTabSelected = false;
 let gShowClosedCourses = true;
@@ -1540,16 +1540,16 @@ function addCourse(course) {
 
 function addToSchedules(course) {
   for (const schedule of gSchedulesChecked) {
-    if (schedule !== gLastScheduleSelected) {
+    if (schedule !== gLastScheduleSelected.id) {
       let oldSchedule = readFromLocalStorage(
-        `selectedCourses-${schedule.id}`,
+        `selectedCourses-${schedule}`,
         _.isArray,
         []
       );
       if (!courseAlreadyAdded(course, oldSchedule)) {
         oldSchedule.push(course);
         localStorage.setItem(
-          `selectedCourses-${schedule.id}`,
+          `selectedCourses-${schedule}`,
           JSON.stringify(oldSchedule)
         );
       }
@@ -1732,8 +1732,8 @@ function handleCurrentScheduleRemoval() {
   defaultRow.classList.add("schedule-active");
   defaultRow.classList.remove("schedule-inactive");
   // check
-  if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
-    gSchedulesChecked.push(gLastScheduleSelected);
+  if (!gSchedulesChecked.includes(gLastScheduleSelected.id)) {
+    gSchedulesChecked.push(gLastScheduleSelected.id);
     const checkBox = defaultRow.children[0].children[0].children[1];
     checkBox.classList.remove("ion-android-checkbox-outline-blank");
     checkBox.classList.add("ion-android-checkbox");
@@ -1995,8 +1995,8 @@ function defaultCheckSchedule(event) {
     event.target.className === "schedule-element btn"
   ) {
     // Only check if not already checked
-    if (!gSchedulesChecked.includes(gLastScheduleSelected)) {
-      gSchedulesChecked.push(gLastScheduleSelected);
+    if (!gSchedulesChecked.includes(gLastScheduleSelected.id)) {
+      gSchedulesChecked.push(gLastScheduleSelected.id);
       const checkBox = event.target.children[0].children[0].children[1];
       checkBox.classList.remove("ion-android-checkbox-outline-blank");
       checkBox.classList.add("ion-android-checkbox");
@@ -2155,7 +2155,7 @@ function writeStateToLocalStorage() {
   localStorage.setItem("lastScheduleId", gLastScheduleId);
   localStorage.setItem(
     "schedulesChecked",
-    JSON.stringify([gLastScheduleSelected])
+    JSON.stringify([gLastScheduleSelected.id])
   );
   localStorage.setItem(
     `selectedCourses-${gLastScheduleSelected.id}`,
@@ -2250,7 +2250,7 @@ function readStateFromLocalStorage() {
   );
   gLastScheduleId = readFromLocalStorage("lastScheduleId", _.isNumber, 1);
   gSchedulesChecked = readFromLocalStorage("schedulesChecked", _.isArray, [
-    gLastScheduleSelected
+    gLastScheduleSelected.id
   ]);
   gSelectedCourses = upgradeSelectedCourses(
     readFromLocalStorage(

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1524,6 +1524,7 @@ function appendScheduleRow(schedule) {
   let checkIcon = document.createElement("i");
   let checkBox = document.createElement("input");
   let deleteButton = document.createElement("i");
+  let editButton = document.createElement("i");
 
   checkLabel.id = `schedule-${scheduleId}-checkbox`;
   checkLabel.classList.add("schedule-label");
@@ -1546,10 +1547,16 @@ function appendScheduleRow(schedule) {
   deleteButton.addEventListener("click", removeSchedule);
   deleteButton.addEventListener("click", catchEvent);
 
+  editButton.classList.add("icon");
+  editButton.classList.add("ion-edit");
+  editButton.classList.add("schedule-edit-button");
+  editButton.addEventListener("click", catchEvent);
+
   newSched.classList.add("schedule-element");
   newSched.classList.add("btn");
   newSched.id = `schedule-${scheduleId}`;
   newSched.appendChild(checkLabel);
+  newSched.appendChild(editButton);
   newSched.appendChild(newName);
   newSched.appendChild(deleteButton);
   newSched.addEventListener("click", selectSchedule);


### PR DESCRIPTION
This is the reworked version of the previous PR regarding multiple schedules. Now there is a dropdown that allows users to create as many schedules as they want. Users can rename and delete the schedules that they make. Bonus features include colorful schedule rows, color changing schedule tab/dropdown, and the schedule tab showing you the name of your currently-selected schedule!

![Screenshot from 2020-05-01 21-53-27](https://user-images.githubusercontent.com/44514622/80855474-47bce980-8bf6-11ea-8897-19092540580f.png)

This is part of CS121 Group 2. Team members include @JeremyTsaii, @godpng, @rory6103.