### PR TITLE
Revert "Enable advanced Fathom Analytics"

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -194,8 +194,8 @@
     <!-- curl -s <src> | shasum -a 384 | cut -f1 -d' ' | xxd -r -p | base64 | sed 's/.*/integrity="sha384-&"/' -->
     <if condition="ANALYTICS">
       <script
-        src="https://encouraging-lovely.b-cdn.net/script.js"
-        data-site="SNRUMQQA"
+        src="https://cdn.usefathom.com/script.js"
+        site="SNRUMQQA"
         defer
       ></script>
     </if>


### PR DESCRIPTION
Reverts MuddCreates/hyperschedule#181

Apparently, the CDN that Fathom was using backed out from under them and they can't offer this feature anymore. Yikes.