### PR TITLE
Turn links in course descriptions into anchor tags in the DOM

### DIFF
--- a/src/css/course-details.pcss
+++ b/src/css/course-details.pcss
@@ -7,6 +7,11 @@
     @apply pb-4;
   }
 
+  a {
+    color: rgb(59, 130, 246);
+    text-decoration: underline;
+  }
+
   header {
     @apply font-bold grid;
     grid-template-areas: "code close" "name close";

--- a/src/js/view/course-details.ts
+++ b/src/js/view/course-details.ts
@@ -2,6 +2,7 @@ import * as Course from "@hyperschedule/lib/course";
 import * as Schedule from "@hyperschedule/lib/schedule";
 import * as Util from "@hyperschedule/lib/util";
 import * as Sidebar from "@hyperschedule/view/sidebar";
+import { string } from "mathjs";
 
 const dom = (() => {
   const container = document.getElementById("course-details")!;
@@ -37,6 +38,14 @@ const hide = () => {
 };
 dom.close.addEventListener("click", hide);
 
+const cleanAnchorTags = (text: any) =>
+  text
+    ? text.replace(
+        /<a href=(.*? )>(.*?)<\/a>/,
+        '<a href="$1" target="blank_">$2</a>'
+      )
+    : "";
+
 export const setCourse = (course: Course.CourseV3) => {
   dom.container.classList.add("show");
   Sidebar.show();
@@ -47,10 +56,11 @@ export const setCourse = (course: Course.CourseV3) => {
   dom.credits.textContent = `${partOfYear(course)}, ${credits} credit${
     credits === 1 ? "" : "s"
   }`;
-  dom.description.textContent = course.courseDescription;
+  dom.description.innerHTML = cleanAnchorTags(course.courseDescription);
 
   if (course.courseEnrollmentStatus) {
-    dom.status.dataset.status = course.courseEnrollmentStatus.toLocaleLowerCase();
+    dom.status.dataset.status =
+      course.courseEnrollmentStatus.toLocaleLowerCase();
     dom.status.textContent = `${capitalize(course.courseEnrollmentStatus)}`;
     dom.seats.textContent = `${course.courseSeatsFilled}/${course.courseSeatsTotal} seats filled`;
   }

--- a/src/js/view/course-details.ts
+++ b/src/js/view/course-details.ts
@@ -37,14 +37,6 @@ const hide = () => {
 };
 dom.close.addEventListener("click", hide);
 
-const cleanAnchorTags = (text: any) =>
-  text
-    ? text.replace(
-        /<a href=(.*? )>(.*?)<\/a>/,
-        '<a href="$1" target="blank_">$2</a>'
-      )
-    : "";
-
 export const setCourse = (course: Course.CourseV3) => {
   dom.container.classList.add("show");
   Sidebar.show();
@@ -55,7 +47,7 @@ export const setCourse = (course: Course.CourseV3) => {
   dom.credits.textContent = `${partOfYear(course)}, ${credits} credit${
     credits === 1 ? "" : "s"
   }`;
-  dom.description.innerHTML = cleanAnchorTags(course.courseDescription);
+  dom.description.innerHTML = course.courseDescription || "";
 
   if (course.courseEnrollmentStatus) {
     dom.status.dataset.status =

--- a/src/js/view/course-details.ts
+++ b/src/js/view/course-details.ts
@@ -2,7 +2,6 @@ import * as Course from "@hyperschedule/lib/course";
 import * as Schedule from "@hyperschedule/lib/schedule";
 import * as Util from "@hyperschedule/lib/util";
 import * as Sidebar from "@hyperschedule/view/sidebar";
-import { string } from "mathjs";
 
 const dom = (() => {
   const container = document.getElementById("course-details")!;


### PR DESCRIPTION
**Description**
I noticed that links appear as literal anchor tags in course descriptions, especially for PE classes. I figured it would be convenient for users if those links were displayed as actual anchor tags.

**Changes**
- Add CSS for anchor tag in `course-details.pcss`
- Add a function for using regex to parse raw anchor tags in course descriptions
- Set description with `.innerHTML()` instead of `.textContent()`
  - `innerHTML` is less efficient than `textContent`, but I imagine the performance drop is marginal