### PR TITLE
Skip on time parse error

### DIFF
--- a/backend/src/hmc-api/data-linker.ts
+++ b/backend/src/hmc-api/data-linker.ts
@@ -460,15 +460,22 @@ function processSectionSchedule(
             continue;
         }
 
-        let startTime, endTime, weekdays;
+        let startTime: number, endTime: number, weekdays: APIv4.Weekday[];
         try {
             startTime = parseTime(schedule.beginTime);
             endTime = parseTime(schedule.endTime);
             weekdays = parseWeekdays(schedule.meetingDays);
         } catch (e) {
             logger.warn(
+                {
+                    err: e,
+                    sectionIdString,
+                    beginTime: schedule.beginTime,
+                    endTime: schedule.endTime,
+                    meetingDays: schedule.meetingDays,
+                    location: schedule.location,
+                },
                 `Malformed schedule for section ${sectionIdString}, skipping...`,
-                e,
             );
             section.potentialError = true;
             continue;

--- a/backend/src/hmc-api/data-linker.ts
+++ b/backend/src/hmc-api/data-linker.ts
@@ -460,9 +460,20 @@ function processSectionSchedule(
             continue;
         }
 
-        const startTime = parseTime(schedule.beginTime);
-        const endTime = parseTime(schedule.endTime);
-        const weekdays = parseWeekdays(schedule.meetingDays);
+        let startTime, endTime, weekdays;
+        try {
+            startTime = parseTime(schedule.beginTime);
+            endTime = parseTime(schedule.endTime);
+            weekdays = parseWeekdays(schedule.meetingDays);
+        } catch (e) {
+            logger.warn(
+                `Malformed schedule for section ${sectionIdString}, skipping...`,
+                e,
+            );
+            section.potentialError = true;
+            continue;
+        }
+
         const location = parseBuildingCode(schedule.location);
 
         let merged: boolean = false;


### PR DESCRIPTION
Instead of preventing all the courses from updating, just skip and print a warning