### PR TITLE
Added class color by campus theme

### DIFF
--- a/frontend/src/components/MiniMap.tsx
+++ b/frontend/src/components/MiniMap.tsx
@@ -170,8 +170,7 @@ export default memo(function MiniMap() {
                                             card.section.identifier,
                                             theme,
                                             courseColorTheme,
-                                            card.section.course.code
-                                                .affiliation,
+                                            card.section.course.primaryAssociation,
                                             true,
                                         ),
                                     }}
@@ -292,7 +291,7 @@ const Card = memo(function Card(props: {
                     props.card.section.identifier,
                     theme,
                     colorTheme,
-                    props.card.section.course.code.affiliation,
+                    props.card.section.course.primaryAssociation,
                     true,
                 ),
             }}

--- a/frontend/src/components/MiniMap.tsx
+++ b/frontend/src/components/MiniMap.tsx
@@ -170,6 +170,8 @@ export default memo(function MiniMap() {
                                             card.section.identifier,
                                             theme,
                                             courseColorTheme,
+                                            card.section.course.code
+                                                .affiliation,
                                             true,
                                         ),
                                     }}
@@ -290,6 +292,7 @@ const Card = memo(function Card(props: {
                     props.card.section.identifier,
                     theme,
                     colorTheme,
+                    props.card.section.course.code.affiliation,
                     true,
                 ),
             }}

--- a/frontend/src/components/MiniMap.tsx
+++ b/frontend/src/components/MiniMap.tsx
@@ -170,7 +170,8 @@ export default memo(function MiniMap() {
                                             card.section.identifier,
                                             theme,
                                             courseColorTheme,
-                                            card.section.course.primaryAssociation,
+                                            card.section.course
+                                                .primaryAssociation,
                                             true,
                                         ),
                                     }}

--- a/frontend/src/components/SelectedList.tsx
+++ b/frontend/src/components/SelectedList.tsx
@@ -268,6 +268,7 @@ const SectionEntry = memo(function SectionEntry(props: {
                     props.entry.section,
                     theme,
                     courseColorTheme,
+                    props.entry.section.affiliation,
                     true,
                 ),
                 transform: DndUtil.CSS.Transform.toString(sortable.transform),

--- a/frontend/src/components/SelectedList.tsx
+++ b/frontend/src/components/SelectedList.tsx
@@ -268,7 +268,7 @@ const SectionEntry = memo(function SectionEntry(props: {
                     props.entry.section,
                     theme,
                     courseColorTheme,
-                    props.entry.section.affiliation,
+                    section?.course.primaryAssociation ?? "monochrome",
                     true,
                 ),
                 transform: DndUtil.CSS.Transform.toString(sortable.transform),

--- a/frontend/src/components/common/SectionBox.tsx
+++ b/frontend/src/components/common/SectionBox.tsx
@@ -1,6 +1,8 @@
 import useStore from "@hooks/store";
 import { sectionColorStyle } from "@lib/color";
-import type * as APIv4 from "hyperschedule-shared/api/v4";
+import * as APIv4 from "hyperschedule-shared/api/v4";
+import { useActiveSectionsLookup } from "@hooks/section";
+
 
 export default function SectionBox(props: {
     section: APIv4.SectionIdentifier;
@@ -11,13 +13,18 @@ export default function SectionBox(props: {
         (store) => store.appearanceOptions.courseColorTheme,
     );
 
+    const sectionsLookup = useActiveSectionsLookup();
+    const section = sectionsLookup.get(
+            APIv4.stringifySectionCodeLong(props.section),
+        );
+
     return (
         <div
             style={sectionColorStyle(
                 props.section,
                 theme,
                 courseColorTheme,
-                props.section.affiliation,
+                section?.course.primaryAssociation ?? "monochrome",
                 false,
             )}
         >

--- a/frontend/src/components/common/SectionBox.tsx
+++ b/frontend/src/components/common/SectionBox.tsx
@@ -17,6 +17,7 @@ export default function SectionBox(props: {
                 props.section,
                 theme,
                 courseColorTheme,
+                props.section.affiliation,
                 false,
             )}
         >

--- a/frontend/src/components/common/SectionBox.tsx
+++ b/frontend/src/components/common/SectionBox.tsx
@@ -3,7 +3,6 @@ import { sectionColorStyle } from "@lib/color";
 import * as APIv4 from "hyperschedule-shared/api/v4";
 import { useActiveSectionsLookup } from "@hooks/section";
 
-
 export default function SectionBox(props: {
     section: APIv4.SectionIdentifier;
     children: JSX.Element;
@@ -15,8 +14,8 @@ export default function SectionBox(props: {
 
     const sectionsLookup = useActiveSectionsLookup();
     const section = sectionsLookup.get(
-            APIv4.stringifySectionCodeLong(props.section),
-        );
+        APIv4.stringifySectionCodeLong(props.section),
+    );
 
     return (
         <div

--- a/frontend/src/components/course-search/CourseRow.tsx
+++ b/frontend/src/components/course-search/CourseRow.tsx
@@ -51,7 +51,7 @@ export default memo(function CourseRow(props: {
                         props.section.identifier,
                         theme,
                         courseColorTheme,
-                        props.section.identifier.affiliation,
+                        props.section.course.primaryAssociation,
                         false,
                     )}
                 >
@@ -85,7 +85,7 @@ export default memo(function CourseRow(props: {
                     props.section.identifier,
                     theme,
                     courseColorTheme,
-                    props.section.course.code.affiliation,
+                    props.section.course.primaryAssociation,
                     false,
                 )}
                 onPointerEnter={() => {

--- a/frontend/src/components/course-search/CourseRow.tsx
+++ b/frontend/src/components/course-search/CourseRow.tsx
@@ -51,6 +51,7 @@ export default memo(function CourseRow(props: {
                         props.section.identifier,
                         theme,
                         courseColorTheme,
+                        props.section.identifier.affiliation,
                         false,
                     )}
                 >
@@ -84,6 +85,7 @@ export default memo(function CourseRow(props: {
                     props.section.identifier,
                     theme,
                     courseColorTheme,
+                    props.section.course.code.affiliation,
                     false,
                 )}
                 onPointerEnter={() => {

--- a/frontend/src/components/popup/Settings.module.css
+++ b/frontend/src/components/popup/Settings.module.css
@@ -131,7 +131,7 @@
         }
 
         & .button[data-theme="campus"] {
-            --theme-color: hsla(0, 0%, 0%, 0%);
+            --theme-color: #ff6b6b;
             background: radial-gradient(circle, #feca57 0%, #ff6b6b 100%);
         }
 

--- a/frontend/src/components/popup/Settings.module.css
+++ b/frontend/src/components/popup/Settings.module.css
@@ -130,6 +130,11 @@
             --theme-color: hsl(133, 29%, 37%);
         }
 
+        & .button[data-theme="campus"] {
+            --theme-color: hsla(0, 0%, 0%, 0%);
+            background: radial-gradient(circle, #feca57 0%, #ff6b6b 100%);
+        }
+
         /* Selected state */
 
         & .button.selected {

--- a/frontend/src/components/popup/Settings.tsx
+++ b/frontend/src/components/popup/Settings.tsx
@@ -159,7 +159,7 @@ const AppearanceSettings = memo(function AppearanceSettings() {
                                 courseColorTheme: color.id,
                             })
                         }
-                        aria-label={`Use ${color.label} color theme`}
+                        aria-label={`Use ${color.label} theme`}
                         aria-pressed={options.courseColorTheme === color.id}
                         title={color.label}
                     />

--- a/frontend/src/components/schedule/Schedule.tsx
+++ b/frontend/src/components/schedule/Schedule.tsx
@@ -190,7 +190,7 @@ const Card = memo(function Card(props: {
                         props.card.section.identifier,
                         theme,
                         courseColorTheme,
-                        props.card.section.course.code.affiliation,
+                        props.card.section.course.primaryAssociation,
                         false,
                     ),
                 } as React.CSSProperties

--- a/frontend/src/components/schedule/Schedule.tsx
+++ b/frontend/src/components/schedule/Schedule.tsx
@@ -190,6 +190,7 @@ const Card = memo(function Card(props: {
                         props.card.section.identifier,
                         theme,
                         courseColorTheme,
+                        props.card.section.course.code.affiliation,
                         false,
                     ),
                 } as React.CSSProperties

--- a/frontend/src/lib/color.ts
+++ b/frontend/src/lib/color.ts
@@ -8,7 +8,8 @@ export type CourseColorTheme =
     | "pastel"
     | "sunset"
     | "cool"
-    | "earthy";
+    | "earthy"
+    | "campus";
 
 export const courseColorThemes: { id: CourseColorTheme; label: string }[] = [
     { id: "default", label: "Default" },
@@ -16,7 +17,20 @@ export const courseColorThemes: { id: CourseColorTheme; label: string }[] = [
     { id: "sunset", label: "Sunset" },
     { id: "cool", label: "Cool" },
     { id: "earthy", label: "Earthy" },
+    { id: "campus", label: "Per Campus Colors" },
 ];
+
+const affiliationColors: Record<string, string> = {
+    PO: "blue", // Pomona
+    HM: "pink", // Harvey Mudd
+    PZ: "orange", // Pitzer
+    CM: "red", // Claremont McKenna
+    SC: "green", // Scripps
+    CG: "purple", // Claremont Graduate
+    KS: "green", // Keck Science Center
+    JP: "pink", // Joint Programs
+    Random: "random", // Random
+};
 
 interface SectionCSSProperties extends React.CSSProperties {
     "--section-color": string;
@@ -134,12 +148,19 @@ export function sectionColorStyle(
     section: APIv4.SectionIdentifier,
     theme: Theme,
     courseColorTheme: CourseColorTheme,
+    affiliation: string,
     strongHighlight: boolean,
 ): SectionCSSProperties {
     // the types published for this package is wrong,
     // actual output is formatted as [H (0-360), S (0-100), V (0-100)]
+
+    let hue =
+        courseColorTheme === "campus"
+            ? affiliationColors[affiliation] ?? "monochrome"
+            : "random";
+
     const colorOut = randomColor({
-        hue: "random",
+        hue: hue,
         luminosity: "light",
         seed: md5(APIv4.stringifySectionCodeLong(section)),
         format: "hsvArray",
@@ -206,7 +227,7 @@ export function sectionColorStyle(
             break;
 
         case "default":
-        default:
+        default: // Handles campus scheme as well
             color = [colorOut[0], colorOut[1], colorOut[2]];
             break;
     }

--- a/frontend/src/lib/color.ts
+++ b/frontend/src/lib/color.ts
@@ -22,14 +22,11 @@ export const courseColorThemes: { id: CourseColorTheme; label: string }[] = [
 
 const affiliationColors: Record<string, string> = {
     PO: "blue", // Pomona
-    HM: "pink", // Harvey Mudd
+    HM: "yellow", // Harvey Mudd
     PZ: "orange", // Pitzer
     CM: "red", // Claremont McKenna
     SC: "green", // Scripps
     CG: "purple", // Claremont Graduate
-    KS: "green", // Keck Science Center
-    JP: "pink", // Joint Programs
-    Random: "random", // Random
 };
 
 interface SectionCSSProperties extends React.CSSProperties {
@@ -224,6 +221,10 @@ export function sectionColorStyle(
                 mapRange(colorOut[1], [25, 53]),
                 mapRange(colorOut[2], [64, 83]),
             ];
+            break;
+
+        case "campus":
+            color = [colorOut[0], colorOut[1], colorOut[2]];
             break;
 
         case "default":

--- a/frontend/src/lib/color.ts
+++ b/frontend/src/lib/color.ts
@@ -224,9 +224,6 @@ export function sectionColorStyle(
             break;
 
         case "campus":
-            color = [colorOut[0], colorOut[1], colorOut[2]];
-            break;
-
         case "default":
         default: // Handles campus scheme as well
             color = [colorOut[0], colorOut[1], colorOut[2]];


### PR DESCRIPTION
New color scheme in settings which will color classes across the UI by affiliation (campus). Most color choices mach up with the colors on the Claremont Colleges website, with the exception of Harvey Mudd in pink as the generated colors were hard to differentiate. Classes that have their affiliation not to a campus will be grey with the exception of the Keck Science center in green (Lot of scripps affiliated courses, thus green to match) and Joint Programs in pink.

(resolves #53)